### PR TITLE
WIP: Add support for MPI-built P4est_jll

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # COMPATHELPER_PRIV: ${{ secrets.COMPATHELPER_PRIV }}  # optional
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs = ["", "test", "deps"])'

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
+MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 CBindingGen = "308a6e0c-0495-45e1-b1ab-67fb455a0d77"
+MPICH_jll = "7cb0a576-ebde-5e09-9194-50597f1243b4"
 P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,19 +1,21 @@
 using CBindingGen
 import P4est_jll
+import MPICH_jll
 
-# Get include directory from jll package
-const incdir = joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include")
+# Get include directories from jll packages
+const incdir_p4est = joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include")
+const incdir_mpich = joinpath(dirname(dirname(MPICH_jll.libmpi_path)), "include")
 
 # Manually set header files to consider
 const hdrs = ["p4est.h", "p8est.h", "p4est_extended.h", "p8est_extended.h"]
 
 # Convert symbols in header
-cvts = convert_headers(hdrs, args = ["-I", incdir]) do cursor
+cvts = convert_headers(hdrs, args = ["-I", incdir_p4est, "-I", incdir_mpich]) do cursor
 	header = CodeLocation(cursor).file
 	name   = string(cursor)
 	
 	# only wrap the libp4est headers
-	startswith(header, "$(incdir)/") || return false
+	startswith(header, "$(incdir_p4est)/") || return false
 
   # Ignore macro hacks
   startswith(name, "sc_extern_c_hack_") && return false

--- a/src/libp4est.jl
+++ b/src/libp4est.jl
@@ -1,5 +1,6 @@
 @reexport baremodule LibP4est
   using CBinding: 𝐣𝐥
+  using MPI: MPI_Datatype, MPI_Comm, MPI_File
   
   # Introduce standard integer types
   const size_t  = 𝐣𝐥.Csize_t


### PR DESCRIPTION
This PR only serves to keep track of a working version with an unpublished P4est_jll with MPI support; before it can seriously be considered for merging we first need to figure out how to switch the p4est library against a system library.