### PR TITLE
update compat entry for CBinding necessary for unsafe_wrap

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "P4est"
 uuid = "7d669430-f675-4ae7-b43e-fab78ec5a902"
 authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
-version = "0.1.0"
+version = "0.1.1-pre"
 
 [deps]
 CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
@@ -9,6 +9,6 @@ P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
 [compat]
-CBinding = "0.9"
+CBinding = "0.9.2"
 Reexport = "0.2"
 julia = "1.5"


### PR DESCRIPTION
With the previous compat bounds, an older version of CBinding installed on my system was used and I couldn't use `unsafe_wrap` as described in the README (the corresponding tests failed, too).