### PR TITLE
Allow using custom libraries without MPI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,11 +52,11 @@ branches:
 #     packages:
 #       - gfortran
 
-# script:
-# default build script along the lines of
-#   using Pkg
-#   Pkg.build() # Pkg.build(; verbose = true) for Julia 1.1 and up
-#   Pkg.test(coverage=true)
+before_script:
+  - ./.travis_install_p4est.sh
+
+script:
+  - julia --color=yes --check-bounds=yes -e 'using Pkg; Pkg.build(; verbose=true); Pkg.test(coverage=true)'
 
 # submit coverage reports (enabled already above) and/or deploy docs
 # after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,15 +47,25 @@ branches:
     - master
 
 # we could install binary dependencies if necessary
-# addons:
-#   apt:
-#     packages:
-#       - gfortran
+addons:
+  apt:
+    packages:
+      - gfortran
 
 before_script:
   - ./.travis_install_p4est.sh
 
 script:
+  # - if [ "${P4EST_TEST}" = "P4EST_JLL_NON_MPI" ]; then
+  #     # nothing to do; equivalent to
+  #     # export JULIA_P4EST_LIBRARY=""
+  #     # export JULIA_P4EST_INCLUDE=""
+  #   fi
+  # - if [ "${P4EST_TEST}" = "P4EST_CUSTOM_NON_MPI" ]; then
+  #     # set library and include paths according to custom build in .travis_install_p4est.sh
+  #     export JULIA_P4EST_LIBRARY="$P4EST_TMP/prefix/lib/libp4est-2.2.so"
+  #     export JULIA_P4EST_INCLUDE="$P4EST_TMP/prefix/include"
+  #   fi
   - julia --color=yes --check-bounds=yes -e 'using Pkg; Pkg.build(; verbose=true); Pkg.test(coverage=true)'
 
 # submit coverage reports (enabled already above) and/or deploy docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,18 +55,9 @@ addons:
 before_script:
   - ./.travis_install_p4est.sh
 
-script:
-  # - if [ "${P4EST_TEST}" = "P4EST_JLL_NON_MPI" ]; then
-  #     # nothing to do; equivalent to
-  #     # export JULIA_P4EST_LIBRARY=""
-  #     # export JULIA_P4EST_INCLUDE=""
-  #   fi
-  # - if [ "${P4EST_TEST}" = "P4EST_CUSTOM_NON_MPI" ]; then
-  #     # set library and include paths according to custom build in .travis_install_p4est.sh
-  #     export JULIA_P4EST_LIBRARY="$P4EST_TMP/prefix/lib/libp4est-2.2.so"
-  #     export JULIA_P4EST_INCLUDE="$P4EST_TMP/prefix/include"
-  #   fi
-  - julia --color=yes --check-bounds=yes -e 'using Pkg; Pkg.build(; verbose=true); Pkg.test(coverage=true)'
+# default build script
+# script:
+#   - julia --color=yes --check-bounds=yes -e 'using Pkg; Pkg.build(; verbose=true); Pkg.test(coverage=true)'
 
 # submit coverage reports (enabled already above) and/or deploy docs
 # after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,20 +26,25 @@ jobs:
     #     - julia --project=docs/ docs/make.jl
     #   after_success: skip
 
-codecov: true
+# coveralls with merging of multiple builds, cf. https://docs.coveralls.io/parallel-build-webhook
 coveralls: true
+env:
+  global:
+    - COVERALLS_PARALLEL=true
+  jobs:
+    - P4EST_TEST=P4EST_JLL_NON_MPI
+    - P4EST_TEST=P4EST_CUSTOM_NON_MPI
+notifications:
+  webhooks: https://coveralls.io/webhook
+  email: false
+
+# codecov merges multiple reports automatically, cf. https://docs.codecov.io/docs/merging-reports
+codecov: true
 
 # avoid duplicate tests in PRs
 branches:
   only:
     - master
-
-notifications:
-  email: false
-
-# we could use groups to trigger multiple builds in parallel to speed-up running expensive tests
-# env:
-#   - GROUP=SomeGroupName
 
 # we could install binary dependencies if necessary
 # addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,13 +51,27 @@ addons:
   apt:
     packages:
       - gfortran
+      - liblapack-dev
+      - libblas-dev
 
 before_script:
   - ./.travis_install_p4est.sh
 
-# default build script
-# script:
-#   - julia --color=yes --check-bounds=yes -e 'using Pkg; Pkg.build(; verbose=true); Pkg.test(coverage=true)'
+script:
+  # nothing to do; equivalent to
+  # export JULIA_P4EST_LIBRARY="";
+  # export JULIA_P4EST_INCLUDE="";
+  - if [[ "${P4EST_TEST}" == "P4EST_JLL_NON_MPI" ]]; then
+      echo "P4EST_JLL_NON_MPI does not require special settings";
+    fi
+  # set library and include paths according to custom build in .travis_install_p4est.sh
+  - if [[ "${P4EST_TEST}" == "P4EST_CUSTOM_NON_MPI" ]]; then
+      export P4EST_TMP=`pwd`/libp4est_tmp;
+      export JULIA_P4EST_LIBRARY="$P4EST_TMP/prefix/lib/libp4est-2.2.so";
+      export JULIA_P4EST_INCLUDE="$P4EST_TMP/prefix/include";
+      echo "P4EST_CUSTOM_NON_MPI requires setting JULIA_P4EST_LIBRARY=$JULIA_P4EST_LIBRARY and JULIA_P4EST_INCLUDE=$JULIA_P4EST_INCLUDE";
+    fi
+  - julia --color=yes --check-bounds=yes -e 'using Pkg; Pkg.build(; verbose=true); Pkg.test(coverage=true)'
 
 # submit coverage reports (enabled already above) and/or deploy docs
 # after_success:

--- a/.travis_install_p4est.sh
+++ b/.travis_install_p4est.sh
@@ -17,4 +17,6 @@ if [ "${P4EST_TEST}" = "P4EST_CUSTOM_NON_MPI" ]; then
   cd test_tmp
   $P4EST_TMP/prefix/bin/p4est_step1
   popd
+  export JULIA_P4EST_LIBRARY="$P4EST_TMP/prefix/lib/libp4est-2.2.so"
+  export JULIA_P4EST_INCLUDE="$P4EST_TMP/prefix/include"
 fi

--- a/.travis_install_p4est.sh
+++ b/.travis_install_p4est.sh
@@ -2,7 +2,7 @@
 
 if [ "${P4EST_TEST}" = "P4EST_CUSTOM_NON_MPI" ]; then
   pushd `pwd`
-  P4EST_TMP=`pwd`/libp4est_tmp
+  export P4EST_TMP=`pwd`/libp4est_tmp
   mkdir -p $P4EST_TMP
   cd $P4EST_TMP/
   wget https://p4est.github.io/release/p4est-2.2.tar.gz

--- a/.travis_install_p4est.sh
+++ b/.travis_install_p4est.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+if [ "${P4EST_TEST}" = "P4EST_JLL_NON_MPI" ]; then
+  echo "Nothing to do for P4EST_TEST=P4EST_JLL_NON_MPI"
+fi
 if [ "${P4EST_TEST}" = "P4EST_CUSTOM_NON_MPI" ]; then
   pushd `pwd`
   export P4EST_TMP=`pwd`/libp4est_tmp

--- a/.travis_install_p4est.sh
+++ b/.travis_install_p4est.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [ "${P4EST_TEST}" = "P4EST_CUSTOM_NON_MPI" ]; then
+  pushd `pwd`
+  P4EST_TMP=`pwd`/libp4est_tmp
+  mkdir -p $P4EST_TMP
+  cd $P4EST_TMP/
+  wget https://p4est.github.io/release/p4est-2.2.tar.gz
+  tar xf p4est-2.2.tar.gz
+  mkdir build
+  cd build/
+  $P4EST_TMP/p4est-2.2/configure --prefix=$P4EST_TMP/prefix
+  make -j 2
+  make install
+  ls -l $P4EST_TMP/prefix/lib/libp4est.so
+  mkdir test_tmp
+  cd test_tmp
+  $P4EST_TMP/prefix/bin/p4est_step1
+  popd
+fi

--- a/README.md
+++ b/README.md
@@ -116,10 +116,11 @@ please refer to the [documentation for p4est itself](http://www.p4est.org/) or t
 ## Authors
 P4est.jl was initiated by
 [Michael Schlottke-Lakemper](https://www.mi.uni-koeln.de/NumSim/schlottke-lakemper)
-and
+(University of Cologne, Germany),
+[Hendrik Ranocha](https://ranocha.de)  (KAUST, Saudi Arabia), and
 [Alexander Astanin](https://www.mi.uni-koeln.de/NumSim/astanin)
-(both University of Cologne, Germany). Together with [Hendrik Ranocha](https://ranocha.de)
-(KAUST, Saudi Arabia), they are the principal developers of P4est.jl.
+(University of Cologne, Germany).
+Together, they are the principal developers of P4est.jl.
 The [p4est](https://github.com/cburstedde/p4est) library itself is written by
 Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac.
 

--- a/README.md
+++ b/README.md
@@ -21,13 +21,22 @@ the following commands in the Julia REPL:
 ```julia
 julia> import Pkg; Pkg.add("P4est")
 ```
-P4est.jl depends on the binary distribution of the `p4est` library, which is
-available in the Julia package `P4est_jll.jl` and which is automatically
+P4est.jl depends on the binary distribution of the [p4est](https://github.com/cburstedde/p4est)
+library, which is available in the Julia package `P4est_jll.jl` and which is automatically
 installed as a dependency.
 
-*Note: Currently, P4est_jll.jl is not available under Windows and provides only
+*Note: Currently, `P4est_jll.jl` is not available under Windows and provides only
 serial binaries without MPI support. Both limitations are planned to be lifted
 in the future.*
+
+You can configure P4est.jl to use a custom build of [p4est](https://github.com/cburstedde/p4est)
+by setting the following environment variables and building P4est.jl again afterwards.
+1. You can set `JULIA_P4EST_PATH`.
+   We will assume to find the corresponding library as
+   `joinpath(ENV["JULIA_P4EST_PATH"], "lib", "libp4est.so")`
+   and the include files in
+   `joinpath(ENV["JULIA_P4EST_PATH"], "include")`.
+2. You can set `JULIA_P4EST_LIBRARY` and `JULIA_P4EST_INCLUDE`.
 
 
 ## Usage
@@ -35,8 +44,9 @@ In the Julia REPL, first load the package P4est.jl
 ```julia
 julia> using P4est
 ```
-You can then access the full `p4est` API that is defined by the headers. For example, to create a
-periodic connectivity and check its validity, execute the following lines:
+You can then access the full [p4est](https://github.com/cburstedde/p4est) API that is defined
+by the headers. For example, to create a periodic connectivity and check its validity, execute
+the following lines:
 ```julia
 julia> conn_ptr = p4est_connectivity_new_periodic()
 Ptr{p4est_connectivity} @0x0000000001ad2080
@@ -60,16 +70,17 @@ true
 julia> p4est_.connectivity.num_trees
 1
 ```
-As can be seen, `unsafe_wrap` allows to convert pointers to `p4est` C structs to
-the corresponding Julia wrapper type provided by
+As can be seen, `unsafe_wrap` allows to convert pointers to [p4est](https://github.com/cburstedde/p4est)
+C structs to the corresponding Julia wrapper type provided by
 [CBinding.jl](https://github.com/analytech-solutions/CBinding.jl). Once
-converted, `CBinding.jl` will automatically wrap pointers nested structures (such as
+converted, [CBinding.jl](https://github.com/analytech-solutions/CBinding.jl)
+will automatically wrap pointers nested structures (such as
 `Ptr{p4est_connectivity}` in `p4est_` in the example above) with the
 corresponding Julia type.
 
-Many functions and types in `p4est` have been documented with comments by the
-`p4est` authors; you can access this documentation as you would for any
-Julia-native entity through `?`:
+Many functions and types in [p4est](https://github.com/cburstedde/p4est) have been documented
+with comments by the [p4est](https://github.com/cburstedde/p4est) authors; you can access this
+documentation as you would for any Julia-native entity through `?`:
 ```
 help?> p4est_memory_used
 search: p4est_memory_used p4est_mesh_memory_used p4est_ghost_memory_used p4est_connectivity_memory_used P4EST_HAVE_MEMORY_H @P4EST_HAVE_MEMORY_H
@@ -98,19 +109,19 @@ search: p4est_memory_used p4est_mesh_memory_used p4est_ghost_memory_used p4est_c
 
 ```
 
-For more information on how to use `p4est` via P4est.jl, please refer to the
-[documentation for p4est itself](http://www.p4est.org/) or to the header files
-(`*.h`) in the
-[p4est repository](https://github.com/cburstedde/p4est/tree/master/src).
+For more information on how to use [p4est](https://github.com/cburstedde/p4est) via P4est.jl,
+please refer to the [documentation for p4est itself](http://www.p4est.org/) or to the header files
+(`*.h`) in the [p4est repository](https://github.com/cburstedde/p4est/tree/master/src).
 
 ## Authors
 P4est.jl was initiated by
 [Michael Schlottke-Lakemper](https://www.mi.uni-koeln.de/NumSim/schlottke-lakemper)
 and
 [Alexander Astanin](https://www.mi.uni-koeln.de/NumSim/astanin)
-(both University of Cologne, Germany), who are also the principal developers.
-The `p4est` library itself is written by Carsten Burstedde, Lucas C. Wilcox, and
-Tobin Isaac.
+(both University of Cologne, Germany). Together with [Hendrik Ranocha](https://ranocha.de)
+(KAUST, Saudi Arabia), they are the principal developers of P4est.jl.
+The [p4est](https://github.com/cburstedde/p4est) library itself is written by
+Carsten Burstedde, Lucas C. Wilcox, and Tobin Isaac.
 
 
 ## License and contributing

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -1,6 +1,8 @@
 [deps]
 CBindingGen = "308a6e0c-0495-45e1-b1ab-67fb455a0d77"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 CBindingGen = "0.4"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -14,28 +14,12 @@ end
 
 config = TOML.parsefile(config_toml)
 
-# P4est.toml has 4 keys
-#  binary   = "" (default) | "system"
-#  path     = "" (default) | top-level directory location
-#  library  = "" (default) | library name/path | list of library names/paths
-#  include  = "" (default) | include name/path | list of include names/paths
+# P4est.toml has 2 keys
+#  library  = "" (default) | library name/path
+#  include  = "" (default) | include name/path
 
 
 # Step 1: Check environment variables and update preferences accordingly
-if haskey(ENV, "JULIA_P4EST_BINARY")
-	config["binary"] = ENV["JULIA_P4EST_BINARY"]
-elseif haskey(ENV, "JULIA_P4EST_LIBRARY") || haskey(ENV, "JULIA_P4EST_PATH")
-	config["binary"] = "system"
-else
-	config["binary"] = ""
-end
-
-if haskey(ENV, "JULIA_P4EST_PATH")
-	config["path"] = ENV["JULIA_P4EST_PATH"]
-else
-	config["path"] = ""
-end
-
 if haskey(ENV, "JULIA_P4EST_LIBRARY")
 	config["library"] = ENV["JULIA_P4EST_LIBRARY"]
 else
@@ -48,12 +32,6 @@ else
 	config["include"] = ""
 end
 
-if haskey(ENV, "JULIA_P4EST_MPI_INCLUDE")
-	config["mpi_include"] = ENV["JULIA_P4EST_MPI_INCLUDE"]
-else
-	config["mpi_include"] = ""
-end
-
 
 open(config_toml, "w") do io
 	TOML.print(io, config)
@@ -62,12 +40,6 @@ end
 
 
 # Step 2: Choose the library according to the settings
-if config["binary"] == ""
-	# TODO
-elseif config["binary"] == "system"
-	# TODO
-end
-
 if isempty(config["library"])
 	println("Use p4est library provided by P4est_jll")
 	p4est_library = P4est_jll.libp4est_path
@@ -89,26 +61,12 @@ else
 	push!(include_directories, config["include"])
 end
 
-if isempty(config["mpi_include"])
-	# println("Use MPI include path provided by P4est_jll")
-	# push!(include_directories,
-	# 			joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include"))
-else
-	println("Use custom MPI include path $(config["mpi_include"])")
-	push!(include_directories, config["mpi_include"])
-end
-
 
 
 # Step 4: Generate binding using the include path according to the settings
 
 # Manually set header files to consider
-# hdrs = ["sc.h", "p4est.h", "p6est.h", "p8est.h"]
-hdrs = ["p4est.h", "p6est.h", "p8est.h"]
-# if !isempty(config["mpi_include"])
-# 	push!(hdrs, "mpi.h")
-# 	push!(hdrs, "mpi-ext.h")
-# end
+hdrs = ["p4est.h", "p4est_extended.h", "p8est.h", "p8est_extended.h"]
 
 # Convert symbols in header
 include_args = String[]
@@ -116,7 +74,6 @@ include_args = String[]
 for dir in include_directories
 	append!(include_args, ("-I", dir))
 end
-@show include_args
 cvts = convert_headers(hdrs, args=include_args) do cursor
 	header = CodeLocation(cursor).file
 	name   = string(cursor)
@@ -126,9 +83,9 @@ cvts = convert_headers(hdrs, args=include_args) do cursor
 	if !(filename in hdrs ||
 		   startswith(filename, "p4est_") ||
 		   startswith(filename, "p6est_") ||
-		   startswith(filename, "p8est_") )#||
-			#  startswith(filename, "sc_") )#||
-			#  filename == "sc.h" )
+		   startswith(filename, "p8est_") ||
+			 startswith(filename, "sc_") ||
+			 filename == "sc.h" )
 		return false
 	end
 	@show filename

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -95,7 +95,9 @@ push!(include_directories, p4est_include)
 # Step 4: Generate binding using the include path according to the settings
 
 # Manually set header files to consider
-hdrs = ["p4est.h", "p4est_extended.h", "p8est.h", "p8est_extended.h"]
+hdrs = ["p4est.h", "p4est_extended.h",
+				"p6est.h", "p6est_extended.h",
+				"p8est.h", "p8est_extended.h"]
 
 # Convert symbols in header
 include_args = String[]

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,28 +1,146 @@
 using CBindingGen
+using Libdl
+import Pkg.TOML
 import P4est_jll
 
-# Get include directory from jll package
-const incdir = joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include")
+
+# setup configuration using ideas from MPI.jl
+config_toml = joinpath(first(DEPOT_PATH), "prefs", "P4est.toml")
+mkpath(dirname(config_toml))
+
+if !isfile(config_toml)
+  touch(config_toml)
+end
+
+config = TOML.parsefile(config_toml)
+
+# P4est.toml has 4 keys
+#  binary   = "" (default) | "system"
+#  path     = "" (default) | top-level directory location
+#  library  = "" (default) | library name/path | list of library names/paths
+#  include  = "" (default) | include name/path | list of include names/paths
+
+
+# Step 1: Check environment variables and update preferences accordingly
+if haskey(ENV, "JULIA_P4EST_BINARY")
+	config["binary"] = ENV["JULIA_P4EST_BINARY"]
+elseif haskey(ENV, "JULIA_P4EST_LIBRARY") || haskey(ENV, "JULIA_P4EST_PATH")
+	config["binary"] = "system"
+else
+	config["binary"] = ""
+end
+
+if haskey(ENV, "JULIA_P4EST_PATH")
+	config["path"] = ENV["JULIA_P4EST_PATH"]
+else
+	config["path"] = ""
+end
+
+if haskey(ENV, "JULIA_P4EST_LIBRARY")
+	config["library"] = ENV["JULIA_P4EST_LIBRARY"]
+else
+	config["library"] = ""
+end
+
+if haskey(ENV, "JULIA_P4EST_INCLUDE")
+	config["include"] = ENV["JULIA_P4EST_INCLUDE"]
+else
+	config["include"] = ""
+end
+
+if haskey(ENV, "JULIA_P4EST_MPI_INCLUDE")
+	config["mpi_include"] = ENV["JULIA_P4EST_MPI_INCLUDE"]
+else
+	config["mpi_include"] = ""
+end
+
+
+open(config_toml, "w") do io
+	TOML.print(io, config)
+end
+
+
+
+# Step 2: Choose the library according to the settings
+if config["binary"] == ""
+	# TODO
+elseif config["binary"] == "system"
+	# TODO
+end
+
+if isempty(config["library"])
+	println("Use p4est library provided by P4est_jll")
+	p4est_library = P4est_jll.libp4est_path
+else
+	println("Use custom p4est library $(config["library"])")
+	p4est_library = config["library"]
+end
+
+
+
+# Step 3: Choose the include path according to the settings
+include_directories = String[]
+if isempty(config["include"])
+	println("Use p4est include path provided by P4est_jll")
+	push!(include_directories,
+				joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include"))
+else
+	println("Use custom p4est include path $(config["include"])")
+	push!(include_directories, config["include"])
+end
+
+if isempty(config["mpi_include"])
+	# println("Use MPI include path provided by P4est_jll")
+	# push!(include_directories,
+	# 			joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include"))
+else
+	println("Use custom MPI include path $(config["mpi_include"])")
+	push!(include_directories, config["mpi_include"])
+end
+
+
+
+# Step 4: Generate binding using the include path according to the settings
 
 # Manually set header files to consider
-const hdrs = ["p4est.h", "p8est.h", "p4est_extended.h", "p8est_extended.h"]
+# hdrs = ["sc.h", "p4est.h", "p6est.h", "p8est.h"]
+hdrs = ["p4est.h", "p6est.h", "p8est.h"]
+# if !isempty(config["mpi_include"])
+# 	push!(hdrs, "mpi.h")
+# 	push!(hdrs, "mpi-ext.h")
+# end
 
 # Convert symbols in header
-cvts = convert_headers(hdrs, args = ["-I", incdir]) do cursor
+include_args = String[]
+@show include_directories
+for dir in include_directories
+	append!(include_args, ("-I", dir))
+end
+@show include_args
+cvts = convert_headers(hdrs, args=include_args) do cursor
 	header = CodeLocation(cursor).file
 	name   = string(cursor)
-	
-	# only wrap the libp4est headers
-	startswith(header, "$(incdir)/") || return false
+
+	# only wrap the libp4est and libsc headers
+	dirname, filename = splitdir(header)
+	if !(filename in hdrs ||
+		   startswith(filename, "p4est_") ||
+		   startswith(filename, "p6est_") ||
+		   startswith(filename, "p8est_") )#||
+			#  startswith(filename, "sc_") )#||
+			#  filename == "sc.h" )
+		return false
+	end
+	@show filename
 
   # Ignore macro hacks
   startswith(name, "sc_extern_c_hack_") && return false
-	
+
 	return true
 end
 
 # Write generated C bindings to file
 const bindings_filename = joinpath(@__DIR__, "libp4est.jl")
 open(bindings_filename, "w+") do io
-	generate(io, P4est_jll.libp4est_path => cvts)
+	generate(io, p4est_library => cvts)
 end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -88,7 +88,6 @@ cvts = convert_headers(hdrs, args=include_args) do cursor
 			 filename == "sc.h" )
 		return false
 	end
-	@show filename
 
   # Ignore macro hacks
   startswith(name, "sc_extern_c_hack_") && return false


### PR DESCRIPTION
This sets up some structure to allow using custom builds of p4est. I wanted to test this using a system provided version of p4est from the Debian repo. However, that one uses MPI and we will have to add all of the relevant MPI includes etc. Hence, I think we should join forces in adding MPI support (#6) and custom p4est builds. 

Closes #5