### PR TITLE
Fix build step on MacOS (workaround)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ installed as a dependency.
 serial binaries without MPI support. Both limitations are planned to be lifted
 in the future.*
 
+*Note: On MacOS, you need to have Xcode installed to be able to use this package.*
+
 You can configure P4est.jl to use a custom build of p4est by setting the
 following environment variables and building P4est.jl again afterwards:
 1. **Set `JULIA_P4EST_PATH`.**

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,10 +4,6 @@ using MPI
 import Pkg.TOML
 import P4est_jll
 
-# Only required on MacOS systems
-const xcode_include_path_cli = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/"
-const xcode_include_path_gui = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
-
 # setup configuration using ideas from MPI.jl
 const config_toml = joinpath(first(DEPOT_PATH), "prefs", "P4est.toml")
 mkpath(dirname(config_toml))
@@ -158,6 +154,9 @@ end
 # Workaround for MacOS: The some headers required by p4est (such as `math.h`) are only available via
 # Xcode
 if Sys.isapple()
+  # These two paths *should* - on any reasonably current MacOS system - contain the relevant headers
+  const xcode_include_path_cli = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/"
+  const xcode_include_path_gui = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
   if !isdir(xcode_include_path_cli) && !isdir(xcode_include_path_gui)
     error("MacOS SDK include paths ('$xcode_include_path_cli' or '$xcode_include_path_gui') do not exist. Have you installed Xcode?")
   end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -5,7 +5,8 @@ import Pkg.TOML
 import P4est_jll
 
 # Only required on MacOS systems
-const xcode_include_path = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
+const xcode_include_path_cli = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/"
+const xcode_include_path_gui = "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/"
 
 # setup configuration using ideas from MPI.jl
 const config_toml = joinpath(first(DEPOT_PATH), "prefs", "P4est.toml")
@@ -157,10 +158,10 @@ end
 # Workaround for MacOS: The some headers required by p4est (such as `math.h`) are only available via
 # Xcode
 if Sys.isapple()
-  if !isdir(xcode_include_path)
-    error("MacOS SDK include path '$xcode_include_path' does not exist. Have you installed Xcode?")
+  if !isdir(xcode_include_path_cli) && !isdir(xcode_include_path_gui)
+    error("MacOS SDK include paths ('$xcode_include_path_cli' or '$xcode_include_path_gui') do not exist. Have you installed Xcode?")
   end
-  append!(include_args, ("-idirafter", xcode_include_path))
+  append!(include_args, ("-idirafter", xcode_include_path_cli, "-idirafter", xcode_include_path_gui))
 end
 
 # Convert symbols in header


### PR DESCRIPTION
This PR should fix the issues on MacOS that were reported by @alexastanin and @andrewwinters5000 on Slack (at least for me).

@alexastanin @andrewwinters5000 Can you please confirm that it works for you if you check out this branch and build P4est.jl from it? Something like this should work:
```bash
git clone git@github.com:trixi-framework/P4est.jl.git
cd P4est.jl
git checkout msl/fix-build-on-macos
julia --project=. -e 'using Pkg; Pkg.build()'
```

If this works for you, we should discuss whether we want to use such a workaround at all, or if we want to use another way how to set up the C bindings for P4est.jl (e.g., by pre-generating them and storing them in the package).