### PR TITLE
Adapt to P4est_jll v2.8 with MPI support

### DIFF
--- a/.ci_install_p4est.sh
+++ b/.ci_install_p4est.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 if [ -z "$P4EST_RELEASE" ]; then
-  P4EST_RELEASE="2.2"
+  P4EST_RELEASE="2.8"
 fi
 
-if [ "${P4EST_TEST}" = "P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS" ]; then
+if [ "${P4EST_TEST}" = "P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS" ]; then
   echo "Found 'P4EST_TEST=${P4EST_TEST}'. Nothing to do here."
 fi
-if [ "${P4EST_TEST}" = "P4EST_JLL_NON_MPI" ]; then
+if [ "${P4EST_TEST}" = "P4EST_JLL_USES_MPI" ]; then
   echo "Found 'P4EST_TEST=${P4EST_TEST}'. Nothing to do here."
 fi
 if [ "${P4EST_TEST}" = "P4EST_CUSTOM_NON_MPI" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,8 @@ jobs:
         arch:
           - x64
         p4est_test:
-          - P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS
-          - P4EST_JLL_NON_MPI
+          - P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS
+          - P4EST_JLL_USES_MPI
           - P4EST_CUSTOM_NON_MPI
           - P4EST_CUSTOM_USES_MPI
         # Only selected tests on macOS and Windows, since not everything works everywhere yet
@@ -51,28 +51,28 @@ jobs:
           - version: '1.6'
             os: macOS-latest
             arch: x64
-            p4est_test: P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS
+            p4est_test: P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS
           - version: '1.6'
             os: macOS-latest
             arch: x64
-            p4est_test: P4EST_JLL_NON_MPI
+            p4est_test: P4EST_JLL_USES_MPI
           - version: '1.6'
             os: windows-latest
             arch: x64
-            p4est_test: P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS
+            p4est_test: P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS
           # Additional tests on Julia v1.7
           - version: '^1.7.0-0'
             os: ubuntu-latest
             arch: x64
-            p4est_test: P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS
+            p4est_test: P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS
           - version: '^1.7.0-0'
             os: macOS-latest
             arch: x64
-            p4est_test: P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS
+            p4est_test: P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS
           - version: '^1.7.0-0'
             os: windows-latest
             arch: x64
-            p4est_test: P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS
+            p4est_test: P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS
     steps:
       - uses: actions/checkout@v2
       - name: Set p4est release to run tests against
@@ -86,9 +86,9 @@ jobs:
           echo "Setting variables for '${{ matrix.p4est_test }}'..."
           echo "P4EST_TEST=${{ matrix.p4est_test }}" >> $GITHUB_ENV
           echo "P4EST_TEST=${{ matrix.p4est_test }}"
-          if [[ ${{ matrix.p4est_test }} == "P4EST_JLL_NON_MPI_PRE_GENERATED_BINDINGS" ]]; then
+          if [[ ${{ matrix.p4est_test }} == "P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS" ]]; then
             echo "(no additional environment variables required)"
-          elif [[ ${{ matrix.p4est_test }} == "P4EST_JLL_NON_MPI" ]]; then
+          elif [[ ${{ matrix.p4est_test }} == "P4EST_JLL_USES_MPI" ]]; then
             echo "JULIA_P4EST_GENERATE_BINDINGS=yes" >> $GITHUB_ENV
             echo "JULIA_P4EST_GENERATE_BINDINGS=yes"
           elif [[ ${{ matrix.p4est_test }} == "P4EST_CUSTOM_NON_MPI" ]]; then

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [libp4est]
-git-tree-sha1 = "45086a10bb6c634ab1f35758ecaadcefbbbbaf13"
+git-tree-sha1 = "ab08f50b99b6c4060e331e5ece8352645c380dd5"
 
     [[libp4est.download]]
-    sha256 = "0ff5f74c9391a9e32fe517327819ac8917a906925605db0569a5beca7b45bcb8"
-    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.3.1+0/P4est.v2.3.1.tar.gz"
+    sha256 = "837eacdd075584af5a5e5f727973b0a216717919ab6e2bdd0200b222c3c3f38d"
+    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.8.0+0/P4est.v2.8.0.tar.gz"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "P4est"
 uuid = "7d669430-f675-4ae7-b43e-fab78ec5a902"
 authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
-version = "0.3.0-prev"
+version = "0.3.0-pre"
 
 [deps]
 CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "P4est"
 uuid = "7d669430-f675-4ae7-b43e-fab78ec5a902"
 authors = ["Michael Schlottke-Lakemper <michael@sloede.com>"]
-version = "0.2.4-pre"
+version = "0.3.0-prev"
 
 [deps]
 CBinding = "d43a6710-96b8-4a2d-833c-c424785e5374"
@@ -12,6 +12,6 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 [compat]
 CBinding = "0.9.2"
 MPI = "0.15, 0.16, 0.18, 0.19"
-P4est_jll = "~2.3.1"
+P4est_jll = "~2.8"
 Reexport = "0.2, 1.0"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ connected adaptive quadtrees or octrees in parallel.
 ## Installation
 If you have not yet installed Julia, please [follow the instructions for your
 operating system](https://julialang.org/downloads/platform/). P4est.jl works
-with Julia v1.6 and up.
+with Julia v1.6.
 
 P4est.jl is a registered Julia package. Hence, you can install it by executing
 the following commands in the Julia REPL:

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ re-generate the bindings by setting the environment variable
 `JULIA_P4EST_GENERATE_BINDINGS` to a non-empty string.
 
 *Note: Currently, `P4est.jl` can only be used with pre-generated bindings on
-Julia v1.7. See [issue #39](https://github.com/trixi-framework/P4est.jl/issues/39)
-for further discussions.*
+Julia v1.7. New bindings can only be generated with Julia v1.6.
+See [issue #39](https://github.com/trixi-framework/P4est.jl/issues/39) for further discussions.*
 
 ### Using a custom build of p4est
 When `JULIA_P4EST_GENERATE_BINDINGS` is non-empty you can also

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ connected adaptive quadtrees or octrees in parallel.
 ## Installation
 If you have not yet installed Julia, please [follow the instructions for your
 operating system](https://julialang.org/downloads/platform/). P4est.jl works
-with Julia v1.6.
+with Julia v1.6 and up.
 
 P4est.jl is a registered Julia package. Hence, you can install it by executing
 the following commands in the Julia REPL:

--- a/README.md
+++ b/README.md
@@ -24,10 +24,9 @@ julia> import Pkg; Pkg.add("P4est")
 ```
 P4est.jl depends on the binary distribution of the [p4est](https://github.com/cburstedde/p4est)
 library, which is available in the Julia package `P4est_jll.jl` and which is automatically
-installed as a dependency.
-
-*Note: Currently, `P4est_jll.jl` only provides serial binaries without MPI
-support. This limitation is planned to be lifted in the future.*
+installed as a dependency. The binaries provided by `P4est_jll.jl` support MPI and are compiled
+against the MPI binaries provided by `MicrosoftMPI_jll.jl` on Windows and `MPICH_jll.jl` on all
+other platforms. Note that `MPI.jl` should be configured to use the same MPI binaries. 
 
 By default, P4est.jl provides pre-generated Julia bindings to all exported C
 functions of the underlying p4est library. You can force the build script to
@@ -38,7 +37,8 @@ re-generate the bindings by setting the environment variable
 Julia v1.7. See [issue #39](https://github.com/trixi-framework/P4est.jl/issues/39)
 for further discussions.*
 
-In addition, when `JULIA_P4EST_GENERATE_BINDINGS` is non-empty you can also
+### Using a custom build of p4est
+When `JULIA_P4EST_GENERATE_BINDINGS` is non-empty you can also
 configure P4est.jl to use a custom build of p4est. For this, set the following
 environment variables and build P4est.jl again afterwards:
 1. **Set `JULIA_P4EST_PATH`.**
@@ -65,10 +65,7 @@ julia --project -e 'ENV["JULIA_P4EST_GENERATE_BINDINGS"] = "yes";
 ```
 
 P4est.jl supports [p4est](https://github.com/cburstedde/p4est) both with and
-without MPI enabled. By default, it uses the p4est library from the binary
-Julia package `P4est_jll`, which currently is not compiled with MPI support.
-However, you may specify a custom p4est build with MPI enabled using the
-environment variables desribed above. In this case, you need to set a few
+without MPI enabled. If your custom build supports MPI, you need to set a few
 additional variables to make sure that P4est.jl can create the correct C
 bindings:
 1. **Set `JULIA_P4EST_USES_MPI` to `yes`.**
@@ -106,25 +103,29 @@ In the Julia REPL, first load the package P4est.jl
 ```julia
 julia> using P4est
 ```
+Then load and initialize MPI
+```julia
+julia> using MPI; MPI.Init()
+```
 You can then access the full [p4est](https://github.com/cburstedde/p4est) API that is defined
 by the headers. For example, to create a periodic connectivity and check its validity, execute
 the following lines:
 ```julia
 julia> conn_ptr = p4est_connectivity_new_periodic()
-Ptr{p4est_connectivity} @0x0000000001ad2080
+Ptr{p4est_connectivity} @0x0000000002412d20
 
 julia> p4est_connectivity_is_valid(conn_ptr)
 1
 
-julia> p4est_ptr = p4est_new_ext(sc_MPI_Comm(0), conn_ptr, 0, 2, 0, 0, C_NULL, C_NULL)
+julia> p4est_ptr = p4est_new_ext(MPI.COMM_WORLD, conn_ptr, 0, 2, 0, 0, C_NULL, C_NULL)
 Into p4est_new with min quadrants 0 level 2 uniform 0
 New p4est with 1 trees on 1 processors
 Initial level 2 potential global quadrants 16 per tree 16
 Done p4est_new with 10 total quadrants
-Ptr{p4est} @0x00000000029e9fc0
+Ptr{p4est} @0x0000000002dd1fd0
 
 julia> p4est_ = unsafe_wrap(p4est_ptr)
-p4est(mpicomm=0, mpisize=1, mpirank=0, mpicomm_owned=0, data_size=0x0000000000000000, user_pointer=Ptr{Nothing} @0x0000000000000000, revision=0, first_local_tree=0, last_local_tree=0, local_num_quadrants=10, global_num_quadrants=10, global_first_quadrant=Ptr{Int64} @0x00000000025b2880, global_first_position=Ptr{p4est_quadrant} @0x0000000001ee1390, connectivity=Ptr{p4est_connectivity} @0x000000000256de60, trees=Ptr{sc_array} @0x0000000002210e20, user_data_pool=Ptr{sc_mempool} @0x0000000000000000, quadrant_pool=Ptr{sc_mempool} @0x00000000020a5820, inspect=Ptr{p4est_inspect} @0x0000000000000000)
+p4est(mpicomm=1140850688, mpisize=1, mpirank=0, mpicomm_owned=0, data_size=0x0000000000000000, user_pointer=Ptr{Nothing} @0x0000000000000000, revision=0, first_local_tree=0, last_local_tree=0, local_num_quadrants=10, global_num_quadrants=10, global_first_quadrant=Ptr{Int64} @0x000000000280c760, global_first_position=Ptr{p4est_quadrant} @0x0000000002a1d270, connectivity=Ptr{p4est_connectivity} @0x0000000002412d20, trees=Ptr{sc_array} @0x0000000002756960, user_data_pool=Ptr{sc_mempool} @0x0000000000000000, quadrant_pool=Ptr{sc_mempool} @0x0000000002dd1e40, inspect=Ptr{p4est_inspect} @0x0000000000000000)
 
 julia> p4est_.connectivity == conn_ptr
 true

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ library, which is available in the Julia package P4est\_jll.jl and which is auto
 installed as a dependency. The binaries provided by P4est\_jll.jl support MPI and are compiled
 against the MPI binaries provided by MicrosoftMPI\_jll.jl on Windows and MPICH\_jll.jl on all
 other platforms. Note that [MPI.jl](https://github.com/JuliaParallel/MPI.jl)
-should be configured to use the same MPI binaries. 
+should be configured to use the same MPI binaries.
 
 By default, P4est.jl provides pre-generated Julia bindings to all exported C
 functions of the underlying p4est library. You can force the build script to
@@ -100,6 +100,10 @@ julia --project -e 'ENV["JULIA_P4EST_GENERATE_BINDINGS"] = "yes";
 ```
 
 ## Usage
+The `P4est.uses_mpi()` function can be used to check if the p4est binaries that P4est.jl uses were
+compiled with MPI enabled. This returns true for the default binaries provided by the P4est_jll.jl
+package. In this case P4est.jl can be used as follows.
+
 In the Julia REPL, first load the packages P4est.jl and MPI.jl in any order and initialize MPI
 ```julia
 julia> using P4est, MPI

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ connected adaptive quadtrees or octrees in parallel.
 ## Installation
 If you have not yet installed Julia, please [follow the instructions for your
 operating system](https://julialang.org/downloads/platform/). P4est.jl works
-with Julia v1.6.
+with Julia v1.6 and up.
 
 P4est.jl is a registered Julia package. Hence, you can install it by executing
 the following commands in the Julia REPL:
@@ -23,17 +23,18 @@ the following commands in the Julia REPL:
 julia> import Pkg; Pkg.add("P4est")
 ```
 P4est.jl depends on the binary distribution of the [p4est](https://github.com/cburstedde/p4est)
-library, which is available in the Julia package `P4est_jll.jl` and which is automatically
-installed as a dependency. The binaries provided by `P4est_jll.jl` support MPI and are compiled
-against the MPI binaries provided by `MicrosoftMPI_jll.jl` on Windows and `MPICH_jll.jl` on all
-other platforms. Note that `MPI.jl` should be configured to use the same MPI binaries. 
+library, which is available in the Julia package P4est\_jll.jl and which is automatically
+installed as a dependency. The binaries provided by P4est\_jll.jl support MPI and are compiled
+against the MPI binaries provided by MicrosoftMPI\_jll.jl on Windows and MPICH\_jll.jl on all
+other platforms. Note that [MPI.jl](https://github.com/JuliaParallel/MPI.jl)
+should be configured to use the same MPI binaries. 
 
 By default, P4est.jl provides pre-generated Julia bindings to all exported C
 functions of the underlying p4est library. You can force the build script to
 re-generate the bindings by setting the environment variable
 `JULIA_P4EST_GENERATE_BINDINGS` to a non-empty string.
 
-*Note: Currently, `P4est.jl` can only be used with pre-generated bindings on
+*Note: Currently, P4est.jl can only be used with pre-generated bindings on
 Julia v1.7. New bindings can only be generated with Julia v1.6.
 See [issue #39](https://github.com/trixi-framework/P4est.jl/issues/39) for further discussions.*
 
@@ -99,13 +100,10 @@ julia --project -e 'ENV["JULIA_P4EST_GENERATE_BINDINGS"] = "yes";
 ```
 
 ## Usage
-In the Julia REPL, first load the package P4est.jl
+In the Julia REPL, first load the packages P4est.jl and MPI.jl in any order and initialize MPI
 ```julia
-julia> using P4est
-```
-Then load and initialize MPI
-```julia
-julia> using MPI; MPI.Init()
+julia> using P4est, MPI
+julia> MPI.Init()
 ```
 You can then access the full [p4est](https://github.com/cburstedde/p4est) API that is defined
 by the headers. For example, to create a periodic connectivity and check its validity, execute

--- a/deps/Artifacts.toml
+++ b/deps/Artifacts.toml
@@ -1,6 +1,6 @@
 [libp4est]
-git-tree-sha1 = "45086a10bb6c634ab1f35758ecaadcefbbbbaf13"
+git-tree-sha1 = "ab08f50b99b6c4060e331e5ece8352645c380dd5"
 
     [[libp4est.download]]
-    sha256 = "0ff5f74c9391a9e32fe517327819ac8917a906925605db0569a5beca7b45bcb8"
-    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.3.1+0/P4est.v2.3.1.tar.gz"
+    sha256 = "837eacdd075584af5a5e5f727973b0a216717919ab6e2bdd0200b222c3c3f38d"
+    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.8.0+0/P4est.v2.8.0.tar.gz"

--- a/deps/Project.toml
+++ b/deps/Project.toml
@@ -5,5 +5,5 @@ P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
-MPI = "0.15, 0.16"
-P4est_jll = "~2.3.1"
+MPI = "0.15, 0.16, 0.18, 0.19"
+P4est_jll = "~2.8"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -129,6 +129,8 @@ else
     p4est_include = joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include")
     println("Use p4est include path provided by P4est_jll")
     use_p4est_jll = true
+  else
+    use_p4est_jll = false
   end
 
   push!(include_directories, p4est_include)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -128,13 +128,14 @@ else
   if isempty(p4est_include)
     p4est_include = joinpath(dirname(dirname(P4est_jll.libp4est_path)), "include")
     println("Use p4est include path provided by P4est_jll")
+    use_p4est_jll = true
   end
 
   push!(include_directories, p4est_include)
 
 
   # Step 3b: Choose the MPI include path according to the settings
-  if config["p4est_uses_mpi"] == "yes"
+  if config["p4est_uses_mpi"] == "yes" || use_p4est_jll # P4est_jll uses MPI
     mpi_include = ""
     if !isempty(config["mpi_include"])
       mpi_include = config["mpi_include"]

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -5,6 +5,11 @@ using Reexport: @reexport
 
 include("libp4est.jl")
 
+"""
+    uses_mpi()
+
+Returns true if the p4est library was compiled with MPI enabled.
+"""
 uses_mpi() = isdefined(@__MODULE__, :P4EST_ENABLE_MPI)
 
 end

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -5,4 +5,6 @@ using Reexport: @reexport
 
 include("libp4est.jl")
 
+uses_mpi() = isdefined(@__MODULE__, :P4EST_ENABLE_MPI)
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Test
 using P4est
 
+const P4EST_TEST = get(ENV, "P4EST_TEST", "")
+
 @testset "P4est.jl tests" begin
   @testset "p4est_connectivity_new_periodic" begin
     @test p4est_connectivity_new_periodic() isa Ptr{p4est_connectivity}
@@ -14,5 +16,17 @@ using P4est
   @testset "unsafe_wrap" begin
     obj = unsafe_wrap(connectivity)
     @test obj.num_vertices == 4
+  end
+  
+  @testset "uses_mpi" begin
+    if P4EST_TEST == "P4EST_JLL_USES_MPI_PRE_GENERATED_BINDINGS"
+      @test P4est.uses_mpi() == true
+    elseif P4EST_TEST == "P4EST_JLL_USES_MPI"
+      @test P4est.uses_mpi() == true
+    elseif P4EST_TEST == "P4EST_CUSTOM_NON_MPI"
+      @test P4est.uses_mpi() == false
+    elseif P4EST_TEST == "P4EST_CUSTOM_USES_MPI"
+      @test P4est.uses_mpi() == true
+    end
   end
 end


### PR DESCRIPTION
- New p4est library requires new bindings, thus the artifacts were adjusted
- The build.jl script automatically includes the MPI library provided by
  MPI.jl when re-generating bindings for P4est_jll
- The README was updated accordingly
- The tutorial in the README uses a proper MPI communicator now because
  the previously used function `sc_MPI_Comm` is only defined if
  p4est is compiled without MPI support
- The point above also implies that this is a breaking change, hence
  the version number was changed as well

Depends on https://github.com/JuliaPackaging/Yggdrasil/pull/4324 and https://github.com/trixi-framework/P4est_jll_bindings/pull/4.

The pre-generated bindings artifact should be attached to a new release of the P4est_jll_bindings repository after the PR there has been merged, please make sure that the links in the Artifacts.toml files in this PR here match that release after it's been made.