### PR TITLE
Wrap quadrant search functions

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,6 +1,6 @@
 [libp4est]
-git-tree-sha1 = "ab08f50b99b6c4060e331e5ece8352645c380dd5"
+git-tree-sha1 = "3f5d810564ee7aa8f388d206123c891e97e65c65"
 
     [[libp4est.download]]
-    sha256 = "837eacdd075584af5a5e5f727973b0a216717919ab6e2bdd0200b222c3c3f38d"
-    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.8.0+0/P4est.v2.8.0.tar.gz"
+    sha256 = "af48410539e41c990300966c22d4012a94d5ac0f05045091687803eaef9d381b"
+    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.8.0+0-v2/P4est.v2.8.0.tar.gz"

--- a/deps/Artifacts.toml
+++ b/deps/Artifacts.toml
@@ -1,6 +1,6 @@
 [libp4est]
-git-tree-sha1 = "ab08f50b99b6c4060e331e5ece8352645c380dd5"
+git-tree-sha1 = "3f5d810564ee7aa8f388d206123c891e97e65c65"
 
     [[libp4est.download]]
-    sha256 = "837eacdd075584af5a5e5f727973b0a216717919ab6e2bdd0200b222c3c3f38d"
-    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.8.0+0/P4est.v2.8.0.tar.gz"
+    sha256 = "af48410539e41c990300966c22d4012a94d5ac0f05045091687803eaef9d381b"
+    url = "https://github.com/trixi-framework/P4est_jll_bindings/releases/download/P4est-v2.8.0+0-v2/P4est.v2.8.0.tar.gz"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -167,9 +167,9 @@ else
   # Step 4: Generate binding using the include path according to the settings
 
   # Manually set header files to consider
-  hdrs = ["p4est.h", "p4est_extended.h",
+  hdrs = ["p4est.h", "p4est_extended.h", "p4est_search.h",
           "p6est.h", "p6est_extended.h",
-          "p8est.h", "p8est_extended.h"]
+          "p8est.h", "p8est_extended.h", "p8est_search.h"]
 
   # Build list of arguments for Clang
   include_args = String[]


### PR DESCRIPTION
Manually add `p4est_search.h` and `p8est_search.h` header files to the list of headers to be wrapped.  This will allow access to `p4est_search` and friends.