### PR TITLE
Add implementation for PointerWrappers

### DIFF
--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -12,6 +12,18 @@ Modules = [P4est]
 ```
 
 
+## PointerWrapper provided by P4est.jl
+
+Everything documented here is also `export`ed from
+[P4est.jl](https://github.com/trixi-framework/P4est.jl) and available when
+`using P4est`.
+
+```@autodocs
+Modules = [P4est.PointerWrappers]
+Private = false
+```
+
+
 ## Wrapper of the C API of [`p4est`](https://github.com/cburstedde/p4est)
 
 Everything documented here is also `export`ed from

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -16,7 +16,7 @@ include("LibP4est.jl")
 
 # Include pointer wrapper
 include("pointerwrappers.jl")
-using .PointerWrappers: PointerWrapper
+@reexport using .PointerWrappers: PointerWrapper
 
 
 # Higher-level API defined in P4est.jl

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -14,6 +14,10 @@ const _PREFERENCE_LIBP4EST = @load_preference("libp4est", "P4est_jll")
 include("LibP4est.jl")
 @reexport using .LibP4est
 
+# Include pointer wrapper
+include("pointerwrappers.jl")
+using .PointerWrappers: PointerWrapper
+
 
 # Higher-level API defined in P4est.jl
 """

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -13,6 +13,8 @@ PointerWrapper(::Type{Ptr{T}}, pointer) where T = PointerWrapper{T}(unsafe_load(
 
 # Cannot use `pw.pointer` since we implement `getproperty` to return the fields of `T` itself
 Base.pointer(pw::PointerWrapper{T}) where T = getfield(pw, :pointer)
+# Allow passing a `PointerWrapper` to wrapped C functions
+Base.unsafe_convert(::Type{Ptr{T}}, pw::PointerWrapper{T}) where {T} = Base.unsafe_convert(Ptr{T}, pointer(pw))
 
 # Syntactic sugar
 Base.propertynames(::PointerWrapper{T}) where T = fieldnames(T)

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -1,0 +1,43 @@
+module PointerWrappers
+
+# Pointer wrapper for conveniently accessing nested structures
+struct PointerWrapper{T}
+  pointer::Ptr{T}
+end
+
+# Non-pointer-type fields get wrapped as a normal PointerWrapper
+PointerWrapper(::Type{T}, pointer) where T = PointerWrapper{T}(pointer)
+
+# Pointer-type fields get dereferenced such that PointerWrapper wraps the pointer to the field type
+PointerWrapper(::Type{Ptr{T}}, pointer) where T = PointerWrapper{T}(unsafe_load(Ptr{Ptr{T}}(pointer)))
+
+# Cannot use `pw.pointer` since we implement `getproperty` to return the fields of `T` itself
+Base.pointer(pw::PointerWrapper{T}) where T = getfield(pw, :pointer)
+
+# Syntactic sugar
+Base.propertynames(::PointerWrapper{T}) where T = fieldnames(T)
+
+# Syntactic sugar: allows one to use `pw.fieldname` to get a PointerWrapper-wrapped pointer to `fieldname`
+function Base.getproperty(pw::PointerWrapper{T}, name::Symbol) where T
+  i = findfirst(isequal(name), fieldnames(T))
+  if isnothing(i)
+    error("type $(string(T)) has no field $name")
+  end
+
+  PointerWrapper(fieldtype(T, i), pointer(pw) + fieldoffset(T, i))
+end
+
+# `[]` allows one to access the actual underlying data
+Base.getindex(pw::PointerWrapper{T}) where T = unsafe_load(pw)
+Base.setindex!(pw::PointerWrapper{T}, value) where T = unsafe_store!(pw, value)
+
+# When `unsafe_load`ing a PointerWrapper object, we really want to load the underlying object
+Base.unsafe_load(pw::PointerWrapper{T}) where T = unsafe_load(pointer(pw))
+
+# If value is of the wrong type, try to convert it
+Base.unsafe_store!(pw::PointerWrapper{T}, value) where T = unsafe_store!(pw, convert(T, value))
+
+# Store value to wrapped location
+Base.unsafe_store!(pw::PointerWrapper{T}, value::T) where T = unsafe_store!(pointer(pw), value)
+
+end

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -28,11 +28,11 @@ function Base.getproperty(pw::PointerWrapper{T}, name::Symbol) where T
 end
 
 # `[]` allows one to access the actual underlying data
-Base.getindex(pw::PointerWrapper{T}) where T = unsafe_load(pw)
-Base.setindex!(pw::PointerWrapper{T}, value) where T = unsafe_store!(pw, value)
+Base.getindex(pw::PointerWrapper) = unsafe_load(pw)
+Base.setindex!(pw::PointerWrapper, value) = unsafe_store!(pw, value)
 
 # When `unsafe_load`ing a PointerWrapper object, we really want to load the underlying object
-Base.unsafe_load(pw::PointerWrapper{T}) where T = unsafe_load(pointer(pw))
+Base.unsafe_load(pw::PointerWrapper) = unsafe_load(pointer(pw))
 
 # If value is of the wrong type, try to convert it
 Base.unsafe_store!(pw::PointerWrapper{T}, value) where T = unsafe_store!(pw, convert(T, value))

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -1,6 +1,41 @@
 module PointerWrappers
 
-# Pointer wrapper for conveniently accessing nested structures
+export PointerWrapper
+
+"""
+    PointerWrapper(p::Ptr)
+
+Wrap the pointer `p` to conveniently access the data of the underlying `struct`.
+Fields of the `struct` (or the `struct` itself) can be dereferenced for reading/writing
+using `[]`. As opposed to using `unsafe_load`/`unsafe_store` on the `struct` directly,
+the `[]` operator only accesses the memory for the requested field, thereby avoiding
+to having to load/store the entire struct when accessing only a single field. This can
+be helpful especially when accessing data in nested structures.
+
+### Example
+```repl
+julia> using P4est, MPI
+
+julia> MPI.Init()
+MPI.ThreadLevel(2)
+
+julia> connectivity = p4est_connectivity_new_brick(2, 2, 0, 0)
+Ptr{p4est_connectivity} @0x000060000378b010
+
+julia> p4est = p4est_new_ext(MPI.COMM_WORLD, connectivity, 0, 0, true, 0, C_NULL, C_NULL)
+Into p4est_new with min quadrants 0 level 0 uniform 1
+New p4est with 4 trees on 1 processors
+Initial level 0 potential global quadrants 4 per tree 1
+Done p4est_new with 4 total quadrants
+Ptr{P4est.LibP4est.p4est} @0x0000600002b9d7b0
+
+julia> p4est_pw = PointerWrapper(p4est)
+PointerWrapper{P4est.LibP4est.p4est}(Ptr{P4est.LibP4est.p4est} @0x0000600002b9d7b0)
+
+julia> p4est_pw.connectivity.num_trees[]
+4
+```
+"""
 struct PointerWrapper{T}
   pointer::Ptr{T}
 end


### PR DESCRIPTION
Here's a demo implementation as a basis for discussion of a convenience wrapper for pointers to p4est C types, to address one of the improvements listed in #54. This is heavily inspired by https://github.com/RelationalAI-oss/Blobs.jl.

Example usage:
```julia
julia> using P4est, MPI; MPI.Init()

julia> connectivity = p4est_connectivity_new_periodic()
Ptr{p4est_connectivity} @0x0000000002412d20

julia> p4est_connectivity_is_valid(connectivity)
1

julia> p4est = p4est_new_ext(MPI.COMM_WORLD, connectivity, 0, 2, 0, 0, C_NULL, C_NULL)
Into p4est_new with min quadrants 0 level 2 uniform 0
New p4est with 1 trees on 1 processors
Initial level 2 potential global quadrants 16 per tree 16
Done p4est_new with 10 total quadrants
Ptr{p4est} @0x0000000002dd1fd0

julia> using P4est: PointerWrapper

julia> pw = PointerWrapper(p4est)
PointerWrapper{P4est.LibP4est.p4est}(Ptr{P4est.LibP4est.p4est} @0x0000000001b3d040)

julia> pw.connectivity.num_trees[]
1

julia> pw.connectivity.num_trees
PointerWrapper{Int32}(Ptr{Int32} @0x0000000001758ea4)

julia> pointer(pw.connectivity.num_trees)
Ptr{Int32} @0x0000000001758ea4
```
One should definitely check thoroughly whether the performance is as expected and whether it would be useful to use `@generated` to avoid some overhead.

### TODO
- [x] check the performance
- [x] add docstrings etc.
- [x] `export PointerWrapper` and explain it in the docs
- [x] decide on final name (something more precise/descriptive/shorter than `PointerWrapper`?)
- [ ] consider adding high level functions that return wrapped pointers instead of raw pointers
- [ ] consider spinning this very orthogonal functionality into a separate package 