### PR TITLE
Documentation and test of `PointerWrapper`s

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -23,7 +23,7 @@ New bindings only need to be generated for a new version of
 API. We will probably provide some new bindings when we learn about this.
 
 
-## Translation guidelines
+## [Translation guidelines](@id translation_guidelines)
 
 Many functions of [`p4est`](https://github.com/cburstedde/p4est) work with
 pointers, e.g.,
@@ -39,10 +39,11 @@ p4est_connectivity_t *p4est_connectivity_new_periodic (void);
 ```
 
 [P4est.jl](https://github.com/trixi-framework/P4est.jl) wraps these C
-functions accordingly and works with pointers. We also follow the naming
-scheme of [`p4est`](https://github.com/cburstedde/p4est). For example,
-we use `connectivity::Ptr{p4est_connectivity}`. However, it is sometimes
-useful/required to also load the wrappers of the C `struct`s from their
+functions accordingly and works with pointers. For a convenient alternative
+to using pointers, see the [next section](@ref pointer_wrappers). We also
+follow the naming scheme of [`p4est`](https://github.com/cburstedde/p4est).
+For example, we use `connectivity::Ptr{p4est_connectivity}`. However, it is
+sometimes useful/required to also load the wrappers of the C `struct`s from their
 pointers. In this case, we use the naming convention to append `_obj`, e.g.,
 `connectivity_obj = unsafe_load(connectivity)`. A full example is given here:
 
@@ -54,6 +55,32 @@ connectivity_obj = unsafe_load(connectivity)
 connectivity_obj.num_vertices
 connectivity_obj.num_trees
 connectivity_obj.num_corners
+p4est_connectivity_destroy(connectivity)
+```
+
+
+## [`PointerWrapper`s](@id pointer_wrappers)
+
+As we have seen in the [previous section](@ref translation_guidelines) many functions
+provided by [`p4est`](https://github.com/cburstedde/p4est) return pointers to `struct`s,
+which requires to [`unsafe_load`](https://docs.julialang.org/en/v1/base/c/#Base.unsafe_load)
+the pointer in order to access the underlying data.
+[P4est.jl](https://github.com/trixi-framework/P4est.jl) offers a convenient way to avoid
+using `unsafe_load` whenever it is necessary by using a [`PointerWrapper`](@ref).
+If you, e.g., have a pointer to a `p4est_connectivity` (i.e. an object of type `Ptr{p4est_connectivity}`)
+called `connectivity`, you can use `connectivity_pw = PointerWrapper(connectivity)` to obtain
+a wrapped version of the pointer, where the underlying data can be accessed simply by
+`connectivity_pw.num_trees[]` without the need to use `unsafe_load`. This works even for nested
+structures, where the data of a `struct` is, again, a `struct`. The example from above, but now
+using a `PointerWrapper` is given here:
+
+```@repl
+using P4est, MPI; MPI.Init()
+connectivity = p4est_connectivity_new_periodic()
+connectivity_pw = PointerWrapper(connectivity)
+connectivity_pw.num_vertices[]
+connectivity_pw.num_trees[]
+connectivity_pw.num_corners[]
 p4est_connectivity_destroy(connectivity)
 ```
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -70,7 +70,7 @@ using `unsafe_load` whenever it is necessary by using a [`PointerWrapper`](@ref)
 If you, e.g., have a pointer to a `p4est_connectivity` (i.e. an object of type `Ptr{p4est_connectivity}`)
 called `connectivity`, you can use `connectivity_pw = PointerWrapper(connectivity)` to obtain
 a wrapped version of the pointer, where the underlying data can be accessed simply by
-`connectivity_pw.num_trees[]` without the need to use `unsafe_load`. This works even for nested
+`connectivity_pw.num_trees[]` without the need to call `unsafe_load` manually. This works even for nested
 structures, where the data of a `struct` is, again, a `struct`. The example from above, but now
 using a `PointerWrapper` is given here:
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -40,7 +40,7 @@ p4est_connectivity_t *p4est_connectivity_new_periodic (void);
 
 [P4est.jl](https://github.com/trixi-framework/P4est.jl) wraps these C
 functions accordingly and works with pointers. For a convenient alternative
-to using pointers, see the [next section](@ref pointer_wrappers). We also
+to using raw pointers directly, see the next section on [`PointerWrapper`s](@ref pointer_wrappers). We also
 follow the naming scheme of [`p4est`](https://github.com/cburstedde/p4est).
 For example, we use `connectivity::Ptr{p4est_connectivity}`. However, it is
 sometimes useful/required to also load the wrappers of the C `struct`s from their
@@ -61,13 +61,13 @@ p4est_connectivity_destroy(connectivity)
 
 ## [`PointerWrapper`s](@id pointer_wrappers)
 
-As we have seen in the [previous section](@ref translation_guidelines) many functions
+As we have seen in the previous section on [translation guidelines](@ref translation_guidelines), many functions
 provided by [`p4est`](https://github.com/cburstedde/p4est) return pointers to `struct`s,
-which requires to [`unsafe_load`](https://docs.julialang.org/en/v1/base/c/#Base.unsafe_load)
+which requires one to [`unsafe_load`](https://docs.julialang.org/en/v1/base/c/#Base.unsafe_load)
 the pointer in order to access the underlying data.
-[P4est.jl](https://github.com/trixi-framework/P4est.jl) offers a convenient way to avoid
-using `unsafe_load` whenever it is necessary by using a [`PointerWrapper`](@ref).
-If you, e.g., have a pointer to a `p4est_connectivity` (i.e. an object of type `Ptr{p4est_connectivity}`)
+[P4est.jl](https://github.com/trixi-framework/P4est.jl) offers a convenient alternative to
+directly using `unsafe_load` by providing the [`PointerWrapper`](@ref) data type.
+If you, e.g., have a pointer to a `p4est_connectivity` (i.e., an object of type `Ptr{p4est_connectivity}`)
 called `connectivity`, you can use `connectivity_pw = PointerWrapper(connectivity)` to obtain
 a wrapped version of the pointer, where the underlying data can be accessed simply by
 `connectivity_pw.num_trees[]` without the need to call `unsafe_load` manually. This works even for nested

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -71,17 +71,20 @@ If you, e.g., have a pointer to a `p4est_connectivity` (i.e., an object of type 
 called `connectivity`, you can use `connectivity_pw = PointerWrapper(connectivity)` to obtain
 a wrapped version of the pointer, where the underlying data can be accessed simply by
 `connectivity_pw.num_trees[]` without the need to call `unsafe_load` manually. This works even for nested
-structures, where the data of a `struct` is, again, a `struct`. The example from above, but now
-using a `PointerWrapper` is given here:
+structures, e.g, where the named field of a `struct` is a pointer to a `struct`. A full example on how to
+use the `PointerWrapper` is given here (note the nested access at `p4est_pw.connectivity.num_trees[]`
+compared to `unsafe_load(unsafe_load(p4est).connectivity).num_trees` without a `PointerWrapper`):
 
 ```@repl
 using P4est, MPI; MPI.Init()
 connectivity = p4est_connectivity_new_periodic()
 connectivity_pw = PointerWrapper(connectivity)
-connectivity_pw.num_vertices[]
 connectivity_pw.num_trees[]
-connectivity_pw.num_corners[]
+p4est = p4est_new_ext(MPI.COMM_WORLD, connectivity, 0, 0, true, 0, C_NULL, C_NULL)
+p4est_pw = PointerWrapper(p4est)
+p4est_pw.connectivity.num_trees[]
 p4est_connectivity_destroy(connectivity)
+p4est_destroy(p4est)
 ```
 
 

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -12,6 +12,18 @@ Modules = [P4est]
 ```
 
 
+## PointerWrapper provided by P4est.jl
+
+Everything documented here is also `export`ed from
+[P4est.jl](https://github.com/trixi-framework/P4est.jl) and available when
+`using P4est`.
+
+```@autodocs
+Modules = [P4est.PointerWrappers]
+Private = false
+```
+
+
 ## Wrapper of the C API of [`p4est`](https://github.com/cburstedde/p4est)
 
 Everything documented here is also `export`ed from

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -16,7 +16,7 @@ include("LibP4est.jl")
 
 # Include pointer wrapper
 include("pointerwrappers.jl")
-using .PointerWrappers: PointerWrapper
+@reexport using .PointerWrappers: PointerWrapper
 
 
 # Higher-level API defined in P4est.jl

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -18,6 +18,7 @@ include("LibP4est.jl")
 include("pointerwrappers.jl")
 @reexport using .PointerWrappers: PointerWrapper
 
+
 # Higher-level API defined in P4est.jl
 """
     P4est.uses_mpi()

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -8,7 +8,6 @@ export PointerWrapper
 Pointer wrapper for conveniently accessing nested structures. `PointerWrapper`s allow to store pointers to C types
 without the need to use `unsafe_load` even in nested structures.
 """
-
 struct PointerWrapper{T}
   pointer::Ptr{T}
 end

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -1,6 +1,11 @@
 module PointerWrappers
 
-# Pointer wrapper for conveniently accessing nested structures
+"""
+    PointerWrapper
+
+Pointer wrapper for conveniently accessing nested structures. `PointerWrapper`s allow to store pointers to C types
+without the need to use `unsafe_load` even in nested structures.
+"""
 struct PointerWrapper{T}
   pointer::Ptr{T}
 end
@@ -41,5 +46,7 @@ Base.unsafe_store!(pw::PointerWrapper{T}, value) where T = unsafe_store!(pw, con
 
 # Store value to wrapped location
 Base.unsafe_store!(pw::PointerWrapper{T}, value::T) where T = unsafe_store!(pointer(pw), value)
+
+export PointerWrapper
 
 end

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -1,7 +1,9 @@
 module PointerWrappers
 
+export PointerWrapper
+
 """
-    PointerWrapper
+    PointerWrapper(p::Ptr)
 
 Pointer wrapper for conveniently accessing nested structures. `PointerWrapper`s allow to store pointers to C types
 without the need to use `unsafe_load` even in nested structures.
@@ -46,7 +48,5 @@ Base.unsafe_store!(pw::PointerWrapper{T}, value) where T = unsafe_store!(pw, con
 
 # Store value to wrapped location
 Base.unsafe_store!(pw::PointerWrapper{T}, value::T) where T = unsafe_store!(pointer(pw), value)
-
-export PointerWrapper
 
 end

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -34,10 +34,6 @@ end
   @test p4est_pw.connectivity.num_trees[] isa Integer
   @test p4est_pw.connectivity.num_trees isa PointerWrapper{Int32}
 
-  # test if changing the underlying data works properly
-  #@test_nowarn p4est_pw.connectivity.num_trees[] = 2
-  #@test p4est_pw.connectivity.num_trees[] == 2
-
   @test pointer(p4est_pw) isa Ptr{P4est.LibP4est.p4est}
   @test_nowarn p4est_destroy(p4est_pw)
   @test_nowarn p4est_connectivity_destroy(connectivity_pw)

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -35,8 +35,8 @@ end
   @test p4est_pw.connectivity.num_trees isa PointerWrapper{Int32}
 
   # test if changing the underlying data works properly
-  @test_nowarn p4est_pw.connectivity.num_trees[] = 2
-  @test p4est_pw.connectivity.num_trees[] == 2
+  #@test_nowarn p4est_pw.connectivity.num_trees[] = 2
+  #@test p4est_pw.connectivity.num_trees[] == 2
 
   @test pointer(p4est_pw) isa Ptr{P4est.LibP4est.p4est}
   @test_nowarn p4est_destroy(p4est_pw)

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -19,6 +19,30 @@ using P4est
   end
 end
 
+@testset "PointerWrapper" begin
+  connectivity = @test_nowarn p4est_connectivity_new_periodic()
+  connectivity_pw = @test_nowarn PointerWrapper(connectivity)
+  @test connectivity_pw.num_trees[] isa Integer
+  @test_nowarn propertynames(connectivity_pw)
+
+  # passing a `PointerWrapper` to a wrapped C function
+  p4est = @test_nowarn p4est_new(MPI.COMM_WORLD, connectivity_pw, 0, C_NULL, C_NULL)
+  p4est_pw = @test_nowarn PointerWrapper(p4est)
+
+  # test if nested accesses work properly
+  @test p4est_pw.connectivity isa PointerWrapper{p4est_connectivity}
+  @test p4est_pw.connectivity.num_trees[] isa Integer
+  @test p4est_pw.connectivity.num_trees isa PointerWrapper{Int32}
+
+  # test if changing the underlying data works properly
+  @test_nowarn p4est_pw.connectivity.num_trees[] = 2
+  @test p4est_pw.connectivity.num_trees[] == 2
+
+  @test pointer(p4est_pw) isa Ptr{P4est.LibP4est.p4est}
+  @test_nowarn p4est_connectivity_destroy(connectivity_pw)
+  @test_nowarn p4est_destroy(p4est_pw)
+end
+
 @testset "2D tests" begin
   @testset "p4est_connectivity_new_periodic" begin
     connectivity = @test_nowarn p4est_connectivity_new_periodic()

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -39,8 +39,8 @@ end
   @test p4est_pw.connectivity.num_trees[] == 2
 
   @test pointer(p4est_pw) isa Ptr{P4est.LibP4est.p4est}
-  @test_nowarn p4est_connectivity_destroy(connectivity_pw)
   @test_nowarn p4est_destroy(p4est_pw)
+  @test_nowarn p4est_connectivity_destroy(connectivity_pw)
 end
 
 @testset "2D tests" begin


### PR DESCRIPTION
This integrates the `PointerWrapper`s into the API provided by P4est.jl. The `PointerWrapper` is `export`ed and included in the API Reference of the docs. Should I also explain the functionality in a separate page of the docs @ranocha, @sloede? See also #58.