### PR TITLE
Add possibility to access arrays from `Pointerwrapper`s

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -87,6 +87,19 @@ p4est_connectivity_destroy(connectivity)
 p4est_destroy(p4est)
 ```
 
+In addition, you can use a `PointerWrapper` as an array if the underlying datastructure is an array, i.e.
+you can access the `i`-th element of the underlying array by `pw[i]` for a `PointerWrapper` `pw`. See the
+following code for a full example:
+
+```@repl
+using P4est, MPI; MPI.Init()
+connectivity = p4est_connectivity_new_periodic()
+p4est = p4est_new_ext(MPI.COMM_WORLD, connectivity, 0, 0, true, 0, C_NULL, C_NULL)
+p4est_pw = PointerWrapper(p4est)
+p4est_pw.global_first_quadrant[2]
+p4est_connectivity_destroy(connectivity)
+p4est_destroy(p4est)
+```
 
 ### Note on MPI datatypes
 

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -64,17 +64,18 @@ function Base.getproperty(pw::PointerWrapper{T}, name::Symbol) where T
   PointerWrapper(fieldtype(T, i), pointer(pw) + fieldoffset(T, i))
 end
 
-# `[]` allows one to access the actual underlying data
-Base.getindex(pw::PointerWrapper) = unsafe_load(pw)
-Base.setindex!(pw::PointerWrapper, value) = unsafe_store!(pw, value)
+# `[]` allows one to access the actual underlying data and
+# `[i]` allows one to access the actual underlying data of an array
+Base.getindex(pw::PointerWrapper, i::Integer=1) = unsafe_load(pw, i)
+Base.setindex!(pw::PointerWrapper, value, i::Integer=1) = unsafe_store!(pw, value, i)
 
 # When `unsafe_load`ing a PointerWrapper object, we really want to load the underlying object
-Base.unsafe_load(pw::PointerWrapper) = unsafe_load(pointer(pw))
+Base.unsafe_load(pw::PointerWrapper, i::Integer=1) = unsafe_load(pointer(pw), i)
 
 # If value is of the wrong type, try to convert it
-Base.unsafe_store!(pw::PointerWrapper{T}, value) where T = unsafe_store!(pw, convert(T, value))
+Base.unsafe_store!(pw::PointerWrapper{T}, value, i::Integer=1) where T = unsafe_store!(pw, convert(T, value), i)
 
 # Store value to wrapped location
-Base.unsafe_store!(pw::PointerWrapper{T}, value::T) where T = unsafe_store!(pointer(pw), value)
+Base.unsafe_store!(pw::PointerWrapper{T}, value::T, i::Integer=1) where T = unsafe_store!(pointer(pw), value, i)
 
 end

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -39,6 +39,14 @@ end
   @test pw.value[] == 0.0
   pw.value[] = 1.0
   @test pw.value[] == 1.0
+  @test pw.value[1] == 1.0
+  pw.value[1] = 2.0
+  @test pw.value[1] == 2.0
+  @test pw.value[] == 2.0
+
+  # test if accessing an underlying array works properly
+  @test p4est_pw.global_first_quadrant[1] isa Integer
+  @test p4est_pw.global_first_quadrant[2] == unsafe_load(unsafe_load(p4est).global_first_quadrant, 2)
 
   # test if nested accesses work properly
   @test p4est_pw.connectivity isa PointerWrapper{p4est_connectivity}


### PR DESCRIPTION
I realized that with the current `PointerWrapper`s it is not conveniently possible to access arrays by simple indexing. Before we did this, e.g. by `unsafe_load(unsafe_load(p4est).global_first_quadrant, 2)`. Now, with a `PointerWrapper` `p4est_pw` we can do `p4est_pw.global_first_quadrant[2]`. Is there any reason why we shouldn't include this functionality?