### PR TITLE
Allow `unsafe_wrap`ping `PointerWrapper`s

### DIFF
--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -72,6 +72,10 @@ Base.setindex!(pw::PointerWrapper, value, i::Integer=1) = unsafe_store!(pw, valu
 # When `unsafe_load`ing a PointerWrapper object, we really want to load the underlying object
 Base.unsafe_load(pw::PointerWrapper, i::Integer=1) = unsafe_load(pointer(pw), i)
 
+# When `unsafe_wrap`ping a PointerWrapper object, we really want to wrap the underlying array
+Base.unsafe_wrap(AType::Union{Type{Array},Type{Array{T}},Type{Array{T,N}}},
+                 pw::PointerWrapper, dims::NTuple{N,Int}; own::Bool = false) where {T,N} = unsafe_wrap(AType, pointer(pw), dims; own)
+
 # If value is of the wrong type, try to convert it
 Base.unsafe_store!(pw::PointerWrapper{T}, value, i::Integer=1) where T = unsafe_store!(pw, convert(T, value), i)
 

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -57,7 +57,7 @@ end
 
   # `unsafe_wrap`ping a `PointerWrapper`
   n_vertices::Int = connectivity_pw.num_vertices[]
-  @test_nowarn vertices = unsafe_wrap(Array, connectivity_pw.vertices, (3, n_vertices))
+  vertices = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, (3, n_vertices))
   @test vertices isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64, 2}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -25,6 +25,10 @@ end
   @test connectivity_pw.num_trees[] isa Integer
   @test_nowarn propertynames(connectivity_pw)
 
+  # `unsafe_wrap`ping a `PointerWrapper`
+  n_vertices::Int = connectivity_pw.num_vertices[]
+  @test unsafe_wrap(Array, connectivity_pw.vertices, (3, n_vertices)) isa Array
+
   # passing a `PointerWrapper` to a wrapped C function
   p4est = @test_nowarn p4est_new(MPI.COMM_WORLD, connectivity_pw, 0, C_NULL, C_NULL)
   p4est_pw = @test_nowarn PointerWrapper(p4est)

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -28,6 +28,8 @@ end
   # `unsafe_wrap`ping a `PointerWrapper`
   n_vertices::Int = connectivity_pw.num_vertices[]
   @test unsafe_wrap(Array, connectivity_pw.vertices, (3, n_vertices)) isa Array
+  @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64}
+  @test unsafe_wrap(Array{Float64, 2}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
 
   # passing a `PointerWrapper` to a wrapped C function
   p4est = @test_nowarn p4est_new(MPI.COMM_WORLD, connectivity_pw, 0, C_NULL, C_NULL)


### PR DESCRIPTION
This convenience function allows to `unsafe_wrap` `PointerWrapper`s.