### PR TITLE
Allow `getproperty` for `PointerWrapper`s with special `struct`s

### DIFF
--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -56,12 +56,19 @@ Base.propertynames(::PointerWrapper{T}) where T = fieldnames(T)
 
 # Syntactic sugar: allows one to use `pw.fieldname` to get a PointerWrapper-wrapped pointer to `fieldname`
 function Base.getproperty(pw::PointerWrapper{T}, name::Symbol) where T
-  i = findfirst(isequal(name), fieldnames(T))
-  if isnothing(i)
-    error("type $(string(T)) has no field $name")
-  end
+  try
+    # For some `struct`s, `fieldnames` isn't implemented, but we can use `Base.getproperty` for pointers,
+    # see https://github.com/trixi-framework/P4est.jl/issues/72
+    return PointerWrapper(Base.getproperty(pointer(pw), name))
+  catch e
+    # In this case we cannot use `Base.getproperty` for the pointer since it is not overwritten, but `fieldnames` works
+    i = findfirst(isequal(name), fieldnames(T))
+    if isnothing(i)
+      error("type $(string(T)) has no field $name")
+    end
 
-  PointerWrapper(fieldtype(T, i), pointer(pw) + fieldoffset(T, i))
+    return PointerWrapper(fieldtype(T, i), pointer(pw) + fieldoffset(T, i))
+  end
 end
 
 # `[]` allows one to access the actual underlying data and

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -51,6 +51,7 @@ end
   # test if nested accesses work properly
   @test p4est_pw.connectivity isa PointerWrapper{p4est_connectivity}
   @test p4est_pw.connectivity.num_trees[] isa Integer
+  @test p4est_pw.global_first_position.level[] isa Integer
   @test p4est_pw.connectivity.num_trees isa PointerWrapper{Int32}
 
   @test pointer(p4est_pw) isa Ptr{P4est.LibP4est.p4est}


### PR DESCRIPTION
This addresses the issue from #72. I'm not 100% sure if this is the proper way to solve the issue since the `try ... catch` seems a bit unsafe to me. But at least the MWE from the issue (and tests) pass. What do you think?