### PR TITLE
Add sugar to set fields with PointerWrapper

### DIFF
--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -89,7 +89,7 @@ p4est_destroy(p4est)
 
 You may also use the `PonterWrapper` to set variables in `struct`s.  Here we
 set the user data pointer in the `p4est_t` `struct` to point to some data:
-```
+```@repl
 using P4est, MPI; MPI.Init()
 connectivity = p4est_connectivity_new_periodic()
 p4est = p4est_new_ext(MPI.COMM_WORLD, connectivity, 0, 0, true, 0, C_NULL, C_NULL)

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -87,6 +87,25 @@ p4est_connectivity_destroy(connectivity)
 p4est_destroy(p4est)
 ```
 
+You may also use the `PonterWrapper` to set variables in `struct`s.  Here we
+set the user data pointer in the `p4est_t` `struct` to point to some data:
+```
+using P4est, MPI; MPI.Init()
+connectivity = p4est_connectivity_new_periodic()
+p4est = p4est_new_ext(MPI.COMM_WORLD, connectivity, 0, 0, true, 0, C_NULL, C_NULL)
+p4est_pw = PointerWrapper(p4est)
+data = Ref((rand(4), rand(5)))
+GC.@preserve data begin
+    p4est_pw.user_pointer = pointer_from_objref(data)
+
+    # Call p4est function with callback that uses p4est_pw.user_pointer here.
+    # You may retrieve the data `Ref` in the callback with
+    # data = unsafe_pointer_to_objref(pointer(p4est_pw.user_pointer))
+end
+p4est_connectivity_destroy(connectivity)
+p4est_destroy(p4est)
+```
+
 In addition, you can use a `PointerWrapper` as an array if the underlying datastructure is an array, i.e.
 you can access the `i`-th element of the underlying array by `pw[i]` for a `PointerWrapper` `pw`. See the
 following code for a full example:

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -64,6 +64,16 @@ function Base.getproperty(pw::PointerWrapper{T}, name::Symbol) where T
   PointerWrapper(fieldtype(T, i), pointer(pw) + fieldoffset(T, i))
 end
 
+# Syntactic sugar: allows one to use `pw.fieldname` to set `fieldname`
+function Base.setproperty!(pw::PointerWrapper{T}, name::Symbol, v) where T
+  i = findfirst(isequal(name), fieldnames(T))
+  if isnothing(i)
+    error("type $(string(T)) has no field $name")
+  end
+
+  unsafe_store!(reinterpret(Ptr{fieldtype(T, i)}, pointer(pw) + fieldoffset(T, i)), v)
+end
+
 # `[]` allows one to access the actual underlying data and
 # `[i]` allows one to access the actual underlying data of an array
 Base.getindex(pw::PointerWrapper, i::Integer=1) = unsafe_load(pw, i)

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -51,6 +51,16 @@ end
   @test pw.value[1] == 2.0
   @test pw.value[] == 2.0
 
+  # test if we can set the user_pointer
+  p4est_pw.user_pointer = Ptr{Cvoid}(3)
+  @test p4est_pw.user_pointer == PointerWrapper(Ptr{Cvoid}(3))
+  data = Ref((2,3))
+  GC.@preserve data begin
+    p4est_pw.user_pointer = pointer_from_objref(data)
+    @test unsafe_pointer_to_objref(pointer(p4est_pw.user_pointer))[] == data[]
+    p4est_pw.user_pointer = C_NULL
+  end
+
   # test if accessing an underlying array works properly
   @test p4est_pw.global_first_quadrant[1] isa Integer
   @test p4est_pw.global_first_quadrant[2] == unsafe_load(unsafe_load(p4est).global_first_quadrant, 2)


### PR DESCRIPTION
This enables the setting of the `user_pointer` field of a `p4est`.  This is useful to access julia data in p4est's callback functions. For example:
```
conn = p4est_connectivity_new_brick(2, 2, 0, 0)
p4est = p4est_new_ext(MPI.COMM_WORLD, conn, 0, 2, 0, 0, C_NULL, C_NULL)
pw = PointerWrapper(p4est)
pw.user_pointer = pointer_from_objref(Ref((3,4)))
```