### PR TITLE
Allow `unsafe_wrap`ping `PointerWrapper`s to vectors

### DIFF
--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -87,7 +87,7 @@ Base.unsafe_load(pw::PointerWrapper, i::Integer=1) = unsafe_load(pointer(pw), i)
 
 # When `unsafe_wrap`ping a PointerWrapper object, we really want to wrap the underlying array
 Base.unsafe_wrap(AType::Union{Type{Array},Type{Array{T}},Type{Array{T,N}}},
-                 pw::PointerWrapper, dims::NTuple{N,Int}; own::Bool = false) where {T,N} = unsafe_wrap(AType, pointer(pw), dims; own)
+                 pw::PointerWrapper, dims::Union{NTuple{N,Int}, Integer}; own::Bool = false) where {T,N} = unsafe_wrap(AType, pointer(pw), dims; own)
 
 # If value is of the wrong type, try to convert it
 Base.unsafe_store!(pw::PointerWrapper{T}, value, i::Integer=1) where T = unsafe_store!(pw, convert(T, value), i)

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -90,11 +90,6 @@ end
   @test vertices isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64, 2}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
-  # wrapping vectors
-  vertices = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, 3 * n_vertices)
-  @test vertices isa Array{Float64, 1}
-  @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
-  @test unsafe_wrap(Array{Float64, 1}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
 
   @test size(vertices) == (3, n_vertices)
   @test vertices[1, 1] == connectivity_pw.vertices[1] == 0.0
@@ -102,6 +97,11 @@ end
   @test vertices[1, 1] == connectivity_pw.vertices[1] == 1.0
   @test_nowarn connectivity_pw.vertices[1] = 2.0
   @test vertices[1, 1] == connectivity_pw.vertices[1] == 2.0
+  # wrapping vectors
+  vertices = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, 3 * n_vertices)
+  @test vertices isa Array{Float64, 1}
+  @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
+  @test unsafe_wrap(Array{Float64, 1}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
 
   @test_nowarn p4est_destroy(p4est_pw)
   @test_nowarn p4est_connectivity_destroy(connectivity_pw)

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -86,20 +86,20 @@ end
   # `unsafe_wrap`ping a `PointerWrapper`
   n_vertices::Int = connectivity_pw.num_vertices[]
   # wrapping matrices
-  vertices = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, (3, n_vertices))
-  @test vertices isa Array{Float64, 2}
+  vertices_matrix = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, (3, n_vertices))
+  @test vertices_matrix isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64, 2}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
 
-  @test size(vertices) == (3, n_vertices)
-  @test vertices[1, 1] == connectivity_pw.vertices[1] == 0.0
-  @test_nowarn vertices[1, 1] = 1.0
-  @test vertices[1, 1] == connectivity_pw.vertices[1] == 1.0
+  @test size(vertices_matrix) == (3, n_vertices)
+  @test vertices_matrix[1, 1] == connectivity_pw.vertices[1] == 0.0
+  @test_nowarn vertices_matrix[1, 1] = 1.0
+  @test vertices_matrix[1, 1] == connectivity_pw.vertices[1] == 1.0
   @test_nowarn connectivity_pw.vertices[1] = 2.0
-  @test vertices[1, 1] == connectivity_pw.vertices[1] == 2.0
+  @test vertices_matrix[1, 1] == connectivity_pw.vertices[1] == 2.0
   # wrapping vectors
-  vertices = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, 3 * n_vertices)
-  @test vertices isa Array{Float64, 1}
+  vertices_vector = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, 3 * n_vertices)
+  @test vertices_vector isa Array{Float64, 1}
   @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
   @test unsafe_wrap(Array{Float64, 1}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
 

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -85,10 +85,16 @@ end
 
   # `unsafe_wrap`ping a `PointerWrapper`
   n_vertices::Int = connectivity_pw.num_vertices[]
+  # wrapping matrices
   vertices = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, (3, n_vertices))
   @test vertices isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
   @test unsafe_wrap(Array{Float64, 2}, connectivity_pw.vertices, (3, n_vertices)) isa Array{Float64, 2}
+  # wrapping vectors
+  vertices = @test_nowarn unsafe_wrap(Array, connectivity_pw.vertices, 3 * n_vertices)
+  @test vertices isa Array{Float64, 1}
+  @test unsafe_wrap(Array{Float64}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
+  @test unsafe_wrap(Array{Float64, 1}, connectivity_pw.vertices, 3 * n_vertices) isa Array{Float64, 1}
 
   @test size(vertices) == (3, n_vertices)
   @test vertices[1, 1] == connectivity_pw.vertices[1] == 0.0


### PR DESCRIPTION
In Trixi.jl we also need to `unsafe_wrap` to vectors, not only to matrices.