### PR TITLE
Allow converting PointerWrappers

### DIFF
--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -43,6 +43,9 @@ end
 # Non-pointer-type fields get wrapped as a normal PointerWrapper
 PointerWrapper(::Type{T}, pointer) where T = PointerWrapper{T}(pointer)
 
+# Allows to convert a PointerWrapper into type `T`, e.g. convert PointerWrapper{Ptr{Nothing}} in PointerWrapper{Int64}
+PointerWrapper(::Type{T}, pw::PointerWrapper) where T = PointerWrapper{T}(pointer(pw))
+
 # Pointer-type fields get dereferenced such that PointerWrapper wraps the pointer to the field type
 PointerWrapper(::Type{Ptr{T}}, pointer) where T = PointerWrapper{T}(unsafe_load(Ptr{Ptr{T}}(pointer)))
 

--- a/src/pointerwrappers.jl
+++ b/src/pointerwrappers.jl
@@ -43,8 +43,12 @@ end
 # Non-pointer-type fields get wrapped as a normal PointerWrapper
 PointerWrapper(::Type{T}, pointer) where T = PointerWrapper{T}(pointer)
 
-# Allows to convert a PointerWrapper into type `T`, e.g. convert PointerWrapper{Ptr{Nothing}} in PointerWrapper{Int64}
-PointerWrapper(::Type{T}, pw::PointerWrapper) where T = PointerWrapper{T}(pointer(pw))
+# Allows to convert a PointerWrapper pointing to `Cvoid` into type `T`, e.g. convert PointerWrapper{Ptr{Nothing}} in PointerWrapper{Int64}
+PointerWrapper(::Type{T}, pw::PointerWrapper{Nothing}) where T = PointerWrapper{T}(pointer(pw))
+PointerWrapper(::Type{T}, pw::PointerWrapper{Ptr{Nothing}}) where T = PointerWrapper{T}(pointer(pw))
+# Allows to convert a PointerWrapper into a PointerWrapper pointing to `Cvoid`
+PointerWrapper(::Type{Nothing}, pw::PointerWrapper) = PointerWrapper{Nothing}(pointer(pw))
+PointerWrapper(::Type{Ptr{Nothing}}, pw::PointerWrapper) = PointerWrapper{Ptr{Nothing}}(pointer(pw))
 
 # Pointer-type fields get dereferenced such that PointerWrapper wraps the pointer to the field type
 PointerWrapper(::Type{Ptr{T}}, pointer) where T = PointerWrapper{T}(unsafe_load(Ptr{Ptr{T}}(pointer)))

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -81,13 +81,20 @@ end
   data_pw = PointerWrapper(Int, data_ptr)
   @test data_pw[1] == 4
   @test data_pw[2] == 5
-  # test if converting a PointerWrapper{Nothing} to PointerWrapper{Int64} works
+  # test if converting a PointerWrappers works
   data_pw_nothing = PointerWrapper(data_ptr)
   @test data_pw_nothing isa PointerWrapper{Nothing}
   data_pw_int = PointerWrapper(Int, data_pw_nothing)
   @test data_pw_int isa PointerWrapper{Int}
   @test data_pw_int[1] == 4
   @test data_pw_int[2] == 5
+  @test PointerWrapper(Nothing, data_pw_int) isa PointerWrapper{Nothing}
+  data_pw_ptr_nothing = PointerWrapper(Ptr{Nothing}, data_pw_int)
+  @test data_pw_ptr_nothing isa PointerWrapper{Ptr{Nothing}}
+  data_pw_int_2 = PointerWrapper(Int, data_pw_ptr_nothing)
+  @test data_pw_int_2 isa PointerWrapper{Int}
+  @test data_pw_int_2[1] == 4
+  @test data_pw_int_2[2] == 5
 
   # test if accessing an underlying array works properly
   @test p4est_pw.global_first_quadrant[1] isa Integer

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -81,7 +81,7 @@ end
   data_pw = PointerWrapper(Int, data_ptr)
   @test data_pw[1] == 4
   @test data_pw[2] == 5
-  # test if converting a PointerWrappers works
+  # test if converting PointerWrappers works
   data_pw_nothing = PointerWrapper(data_ptr)
   @test data_pw_nothing isa PointerWrapper{Nothing}
   data_pw_int = PointerWrapper(Int, data_pw_nothing)

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -44,16 +44,20 @@ end
   ptr = Base.unsafe_convert(Ptr{MyStruct}, Ref(obj))
   pw = PointerWrapper(ptr)
   @test pw.value[] == 0.0
+  @test unsafe_load(ptr).value == 0.0
   @test_nowarn pw.value[] = 1.0
   @test pw.value[] == 1.0
   @test pw.value[1] == 1.0
+  @test unsafe_load(ptr).value == 1.0
   @test_nowarn pw.value[1] = 2.0
   @test pw.value[1] == 2.0
   @test pw.value[] == 2.0
+  @test unsafe_load(ptr).value == 2.0
   # using `setproperty!`
   @test_nowarn pw.value = 3.0
   @test pw.value[1] == 3.0
   @test pw.value[] == 3.0
+  @test unsafe_load(ptr).value == 3.0
   # using `setproperty!` for special `struct`s
   # see https://github.com/trixi-framework/P4est.jl/issues/72 and https://github.com/trixi-framework/P4est.jl/issues/79
   @test p4est_pw.global_first_position.level[] == 29
@@ -70,6 +74,20 @@ end
     @test unsafe_pointer_to_objref(pointer(p4est_pw.user_pointer))[] == data[]
     p4est_pw.user_pointer = C_NULL
   end
+
+  data_ref = Ref((4,5))
+  data_ptr = pointer_from_objref(data_ref)
+  # test if wrapping a Ptr{Nothing} as PointerWrapper{Int} works
+  data_pw = PointerWrapper(Int, data_ptr)
+  @test data_pw[1] == 4
+  @test data_pw[2] == 5
+  # test if converting a PointerWrapper{Nothing} to PointerWrapper{Int64} works
+  data_pw_nothing = PointerWrapper(data_ptr)
+  @test data_pw_nothing isa PointerWrapper{Nothing}
+  data_pw_int = PointerWrapper(Int, data_pw_nothing)
+  @test data_pw_int isa PointerWrapper{Int}
+  @test data_pw_int[1] == 4
+  @test data_pw_int[2] == 5
 
   # test if accessing an underlying array works properly
   @test p4est_pw.global_first_quadrant[1] isa Integer


### PR DESCRIPTION
As discussed in https://github.com/trixi-framework/Trixi.jl/pull/1434 it is  sometimes useful to convert a `PointerWrapper{Nothing}` into a `PointerWrapper{Int}`. I added this functionality (and also added some additional tests).