### PR TITLE
Allow `using P4est` for preferences not set correctly

### DIFF
--- a/dev/prologue.jl
+++ b/dev/prologue.jl
@@ -2,14 +2,19 @@ using P4est_jll: P4est_jll
 export P4est_jll
 
 using ..P4est: _PREFERENCE_LIBP4EST, _PREFERENCE_LIBSC
+using MPIPreferences: MPIPreferences
 
-@static if _PREFERENCE_LIBP4EST == "P4est_jll"
+@static if _PREFERENCE_LIBP4EST == "P4est_jll" && MPIPreferences.binary == "system"
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+elseif _PREFERENCE_LIBP4EST == "P4est_jll"
     const libp4est = P4est_jll.libp4est
 else
     const libp4est = _PREFERENCE_LIBP4EST
 end
 
-@static if _PREFERENCE_LIBSC == "P4est_jll"
+@static if _PREFERENCE_LIBSC == "P4est_jll" && MPIPreferences.binary == "system"
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+elseif _PREFERENCE_LIBSC == "P4est_jll"
     const libsc = P4est_jll.libsc
 else
     const libsc = _PREFERENCE_LIBSC

--- a/dev/prologue.jl
+++ b/dev/prologue.jl
@@ -5,7 +5,7 @@ using ..P4est: _PREFERENCE_LIBP4EST, _PREFERENCE_LIBSC
 using MPIPreferences: MPIPreferences
 
 @static if _PREFERENCE_LIBP4EST == "P4est_jll" && MPIPreferences.binary == "system"
-    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences, see https://trixi-framework.github.io/P4est.jl/stable/#Using-a-custom-version-of-MPI-and/or-p4est."
 elseif _PREFERENCE_LIBP4EST == "P4est_jll"
     const libp4est = P4est_jll.libp4est
 else
@@ -13,7 +13,7 @@ else
 end
 
 @static if _PREFERENCE_LIBSC == "P4est_jll" && MPIPreferences.binary == "system"
-    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences, see https://trixi-framework.github.io/P4est.jl/stable/#Using-a-custom-version-of-MPI-and/or-p4est."
 elseif _PREFERENCE_LIBSC == "P4est_jll"
     const libsc = P4est_jll.libsc
 else

--- a/src/LibP4est.jl
+++ b/src/LibP4est.jl
@@ -14,7 +14,7 @@ using ..P4est: _PREFERENCE_LIBP4EST, _PREFERENCE_LIBSC
 using MPIPreferences: MPIPreferences
 
 @static if _PREFERENCE_LIBP4EST == "P4est_jll" && MPIPreferences.binary == "system"
-    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences, see https://trixi-framework.github.io/P4est.jl/stable/#Using-a-custom-version-of-MPI-and/or-p4est."
 elseif _PREFERENCE_LIBP4EST == "P4est_jll"
     const libp4est = P4est_jll.libp4est
 else
@@ -22,7 +22,7 @@ else
 end
 
 @static if _PREFERENCE_LIBSC == "P4est_jll" && MPIPreferences.binary == "system"
-    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences, see https://trixi-framework.github.io/P4est.jl/stable/#Using-a-custom-version-of-MPI-and/or-p4est."
 elseif _PREFERENCE_LIBSC == "P4est_jll"
     const libsc = P4est_jll.libsc
 else

--- a/src/LibP4est.jl
+++ b/src/LibP4est.jl
@@ -11,14 +11,19 @@ using P4est_jll: P4est_jll
 export P4est_jll
 
 using ..P4est: _PREFERENCE_LIBP4EST, _PREFERENCE_LIBSC
+using MPIPreferences: MPIPreferences
 
-@static if _PREFERENCE_LIBP4EST == "P4est_jll"
+@static if _PREFERENCE_LIBP4EST == "P4est_jll" && MPIPreferences.binary == "system"
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+elseif _PREFERENCE_LIBP4EST == "P4est_jll"
     const libp4est = P4est_jll.libp4est
 else
     const libp4est = _PREFERENCE_LIBP4EST
 end
 
-@static if _PREFERENCE_LIBSC == "P4est_jll"
+@static if _PREFERENCE_LIBSC == "P4est_jll" && MPIPreferences.binary == "system"
+    @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+elseif _PREFERENCE_LIBSC == "P4est_jll"
     const libsc = P4est_jll.libsc
 else
     const libsc = _PREFERENCE_LIBSC

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -145,7 +145,7 @@ function __init__()
             @warn "Detected version $(version) of `p4est`. Currently, we only support versions v2.x.y from v2.3.0 on. Not everything may work correctly."
         end
     else
-        @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
+        @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences, see https://trixi-framework.github.io/P4est.jl/stable/#Using-a-custom-version-of-MPI-and/or-p4est."
     end
 
     return nothing

--- a/src/P4est.jl
+++ b/src/P4est.jl
@@ -144,6 +144,8 @@ function __init__()
         if !(v"2.3" <= version < v"3-")
             @warn "Detected version $(version) of `p4est`. Currently, we only support versions v2.x.y from v2.3.0 on. Not everything may work correctly."
         end
+    else
+        @warn "System MPI version detected, but not a system p4est version. To make P4est.jl work, you need to set the preferences."
     end
 
     return nothing


### PR DESCRIPTION
With this PR `using P4est` doesn't crash anymore if a system-provided MPI installation together with the P4est_jll p4est version is used, but gives the user a warning to set the preferences for p4est accordingly. This way, it is also possible to **first** set the MPIPreferences, restart the REPL and **then** set the preferences for P4est.jl.

Additionally, I have added three functions: `path_p4est_library()` and `path_sc_library()`, which returns the path to the libraries or `P4est_jll` if the default p4est installation is used. This way one can conveniently check if P4est.jl uses the correct libraries.

Lastly, I added the function `preferences_set_correctly()`, which returns `false` if P4est.jl is not usable due to missing preference for P4est.jl. This function can be used in Trixi.jl to determine if [`init_p4est()`](https://github.com/trixi-framework/Trixi.jl/blob/main/src/auxiliary/p4est.jl#L15) can be called or not. By adding `if preferences_set_correctly() ... end` together with my corresponding PR in T8code.jl (https://github.com/DLR-AMR/T8code.jl/pull/40), I was able to run Trixi.jl with system-provided MPI installation on a `TreeMesh`-example without setting the preferences for P4est.jl and T8code.jl. Thus, with these two PRs and the corresponding PR in Trixi.jl (that I will prepare once this PR and the corresponding T8code.jl PR are merged) it is only necessary to set the preferences for P4est.jl and T8code.jl if you really need them.

Closes #91.