### PR TITLE
bump compat for CEnum to v0.5

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-CEnum = "0.4"
+CEnum = "0.4, 0.5"
 MPI = "0.20"
 MPIPreferences = "0.1"
 P4est_jll = "~2.8"


### PR DESCRIPTION
CompatHelper was disabled due to inactivity in this repo. I activated it again - and noticed that there was a pending update.