### PR TITLE
Use debug-mode in CI testing

### DIFF
--- a/.ci_install_p4est.sh
+++ b/.ci_install_p4est.sh
@@ -21,7 +21,7 @@ if [ "${JULIA_P4EST_TEST}" = "P4EST_CUSTOM_MPI_CUSTOM" ]; then
   export CXX=mpicxx
   export FC=mpif90
   export F77=mpif77
-  $P4EST_TMP/p4est-${P4EST_RELEASE}/configure --prefix=$P4EST_TMP/prefix --enable-mpi
+  $P4EST_TMP/p4est-${P4EST_RELEASE}/configure --prefix=$P4EST_TMP/prefix --enable-mpi --enable-debug
   make -j 2
   make install
   ls -l $P4EST_TMP/prefix/lib/libp4est.so

--- a/test/test_nested_attributes_2d.jl
+++ b/test/test_nested_attributes_2d.jl
@@ -18,7 +18,7 @@ end
 
 function refine_fn(p4est, which_tree, quadrant)
   quadrant_obj = unsafe_load(quadrant)
-  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 4
+  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 2
     return Cint(1)
   else
     return Cint(0)

--- a/test/test_nested_attributes_2d.jl
+++ b/test/test_nested_attributes_2d.jl
@@ -18,7 +18,7 @@ end
 
 function refine_fn(p4est, which_tree, quadrant)
   quadrant_obj = unsafe_load(quadrant)
-  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 2
+  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 4
     return Cint(1)
   else
     return Cint(0)
@@ -80,6 +80,7 @@ end
   refine_fn_c = @cfunction(refine_fn, Cint,
                            (Ptr{p4est_t}, Ptr{p4est_topidx_t}, Ptr{p4est_quadrant_t}))
   p4est_refine(p4est, true, refine_fn_c, C_NULL)
+  p4est_balance(p4est, P4EST_CONNECT_FACE, C_NULL)
 
   iter_face_c = @cfunction(iter_face, Cvoid,
                            (Ptr{p4est_iter_face_info_t}, Ptr{Cvoid}))

--- a/test/test_nested_attributes_3d.jl
+++ b/test/test_nested_attributes_3d.jl
@@ -17,7 +17,7 @@ end
 
 function refine_fn(p4est, which_tree, quadrant)
   quadrant_obj = unsafe_load(quadrant)
-  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 4
+  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 2
     return Cint(1)
   else
     return Cint(0)

--- a/test/test_nested_attributes_3d.jl
+++ b/test/test_nested_attributes_3d.jl
@@ -17,7 +17,7 @@ end
 
 function refine_fn(p4est, which_tree, quadrant)
   quadrant_obj = unsafe_load(quadrant)
-  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 2
+  if quadrant_obj.x == 0 && quadrant_obj.y == 0 && quadrant_obj.level < 4
     return Cint(1)
   else
     return Cint(0)
@@ -80,6 +80,7 @@ end
   refine_fn_c = @cfunction(refine_fn, Cint,
                            (Ptr{p8est_t}, Ptr{p4est_topidx_t}, Ptr{p8est_quadrant_t}))
   p8est_refine(p4est, true, refine_fn_c, C_NULL)
+  p8est_balance(p4est, P8EST_CONNECT_FACE, C_NULL)
 
   iter_face_nested_attributes_c = @cfunction(iter_face, Cvoid,
                                              (Ptr{p8est_iter_face_info_t}, Ptr{Cvoid}))

--- a/test/tests_basic.jl
+++ b/test/tests_basic.jl
@@ -216,7 +216,7 @@ end
 
   @testset "local_num_quadrants" begin
     connectivity = @test_nowarn p8est_connectivity_new_periodic()
-    p4est = @test_nowarn p4est_new(MPI.COMM_WORLD, connectivity, 0, C_NULL, C_NULL)
+    p4est = @test_nowarn p8est_new(MPI.COMM_WORLD, connectivity, 0, C_NULL, C_NULL)
     @test_nowarn Int(unsafe_load(p4est).local_num_quadrants)
   end
 


### PR DESCRIPTION
I've noticed (e.g. [here](https://github.com/trixi-framework/P4est.jl/pull/90#issuecomment-1763365340)) that `p4est` throws some errors in our tests, when debug-mode is enabled. I therefore suggest to enable `--enable-debug` in our CI testing as proposed in this PR. I have also adjusted our tests such that `p4est` doesn't throw the errors anymore. This is also related to https://github.com/trixi-framework/Trixi.jl/issues/1358 since there `p4est` also throws an error if debug-mode is enabled, although I'm not sure why.