### PR TITLE
Skip static functions when generating the bindings

### DIFF
--- a/dev/Manifest.toml
+++ b/dev/Manifest.toml
@@ -1,10 +1,12 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.7.3"
+julia_version = "1.9.3"
 manifest_format = "2.0"
+project_hash = "b318b16848fa4a5ae80166fcd22b833bc2ad0770"
 
 [[deps.ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[deps.Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -19,19 +21,20 @@ version = "0.4.2"
 
 [[deps.Clang]]
 deps = ["CEnum", "Clang_jll", "Downloads", "Pkg", "TOML"]
-git-tree-sha1 = "32908e9e1700e17f3676a4a097f176629b6bcdaf"
+git-tree-sha1 = "17e51c980e1797210f30155d18ea5a2f02b80833"
 uuid = "40e3b903-d033-50b4-a0cc-940c62c95e31"
-version = "0.16.5"
+version = "0.17.7"
 
 [[deps.Clang_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll", "libLLVM_jll"]
-git-tree-sha1 = "8cf7e67e264dedc5d321ec87e78525e958aea057"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "TOML", "Zlib_jll", "libLLVM_jll"]
+git-tree-sha1 = "124bb00d4ceace456054f17c7cb01e5c8195c609"
 uuid = "0ee61d77-7f21-5576-8119-9fcc46b10100"
-version = "12.0.1+3"
+version = "14.0.6+4"
 
 [[deps.CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.0.5+0"
 
 [[deps.Dates]]
 deps = ["Printf"]
@@ -50,6 +53,7 @@ version = "0.9.3"
 [[deps.Downloads]]
 deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
 
 [[deps.FileWatching]]
 uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
@@ -59,10 +63,10 @@ deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[deps.JLLWrappers]]
-deps = ["Preferences"]
-git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
+deps = ["Artifacts", "Preferences"]
+git-tree-sha1 = "7e5d6779a1e09a36db2a7b6cff50942a0a7d0fca"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.4.1"
+version = "1.5.0"
 
 [[deps.LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -71,10 +75,12 @@ uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 [[deps.LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
 
 [[deps.LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.84.0+0"
 
 [[deps.LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
@@ -83,6 +89,7 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 [[deps.LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.10.2+0"
 
 [[deps.Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
@@ -91,28 +98,36 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.MPI]]
-deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Requires", "Serialization", "Sockets"]
-git-tree-sha1 = "923991e1023c2f883ab6fc3e7d81580dc833eee0"
+deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "PkgVersion", "PrecompileTools", "Requires", "Serialization", "Sockets"]
+git-tree-sha1 = "9dc0c2c256d8b53324770738e54083622f2ca187"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-version = "0.20.5"
+version = "0.20.18"
+
+    [deps.MPI.extensions]
+    AMDGPUExt = "AMDGPU"
+    CUDAExt = "CUDA"
+
+    [deps.MPI.weakdeps]
+    AMDGPU = "21141c5a-9bdb-4563-92ae-f87d6854732e"
+    CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [[deps.MPICH_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "Pkg", "TOML"]
-git-tree-sha1 = "6d4fa43afab4611d090b11617ecea1a144b21d35"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "8a5b4d2220377d1ece13f49438d71ad20cf1ba83"
 uuid = "7cb0a576-ebde-5e09-9194-50597f1243b4"
-version = "4.0.2+5"
+version = "4.1.2+0"
 
 [[deps.MPIPreferences]]
 deps = ["Libdl", "Preferences"]
-git-tree-sha1 = "71f937129731a29eabe6969db2c90368a4408933"
+git-tree-sha1 = "8f6af051b9e8ec597fa09d8885ed79fd582f33c9"
 uuid = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
-version = "0.1.7"
+version = "0.1.10"
 
 [[deps.MPItrampoline_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "Pkg", "TOML"]
-git-tree-sha1 = "b3f9e42685b4ad614eca0b44bd863cd41b1c86ea"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "6979eccb6a9edbbb62681e158443e79ecc0d056a"
 uuid = "f1f71cc9-e9ae-5b93-9b94-4fe0e1ad3748"
-version = "5.0.2+1"
+version = "5.3.1+0"
 
 [[deps.Markdown]]
 deps = ["Base64"]
@@ -121,40 +136,56 @@ uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 [[deps.MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.2+0"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "a16aa086d335ed7e0170c5265247db29172af2f9"
+git-tree-sha1 = "b01beb91d20b0d1312a9471a36017b5b339d26de"
 uuid = "9237b28f-5490-5468-be7b-bb81f5f5e6cf"
-version = "10.1.3+2"
+version = "10.1.4+1"
 
 [[deps.MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.10.11"
 
 [[deps.NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
 
 [[deps.OpenMPI_jll]]
-deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "Pkg", "TOML"]
-git-tree-sha1 = "346d6b357a480300ed7854dbc70e746ac52e10fd"
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "TOML"]
+git-tree-sha1 = "e25c1778a98e34219a00455d6e4384e017ea9762"
 uuid = "fe0851c0-eecd-5654-98d4-656369965a5c"
-version = "4.1.3+3"
+version = "4.1.6+0"
 
 [[deps.P4est_jll]]
 deps = ["Artifacts", "JLLWrappers", "LazyArtifacts", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Pkg", "TOML", "Zlib_jll"]
-git-tree-sha1 = "d4b48fd3ca75a398916c58c1e4628bf0ce11a7b6"
+git-tree-sha1 = "70c2d9a33b8810198314a5722ee3e9520110b28d"
 uuid = "6b5a15aa-cf52-5330-8376-5e5d90283449"
-version = "2.8.1+0"
+version = "2.8.1+2"
 
 [[deps.Pkg]]
-deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+deps = ["Artifacts", "Dates", "Downloads", "FileWatching", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.9.2"
+
+[[deps.PkgVersion]]
+deps = ["Pkg"]
+git-tree-sha1 = "f9501cc0430a26bc3d156ae1b5b0c1b47af4d6da"
+uuid = "eebad327-c553-4316-9ea0-9fa01ccd7688"
+version = "0.3.3"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "03b4c25b43cb84cee5c90aa9b5ea0a78fd848d2f"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.2.0"
 
 [[deps.Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "47e5f437cc0e7ef2ce8406ce1e7e24d44915f88d"
+git-tree-sha1 = "00805cd429dcb4870060ff49ef443486c262e38e"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.3.0"
+version = "1.4.1"
 
 [[deps.Printf]]
 deps = ["Unicode"]
@@ -176,6 +207,7 @@ version = "1.3.0"
 
 [[deps.SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[deps.Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
@@ -186,10 +218,12 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 [[deps.TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
 
 [[deps.Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
 
 [[deps.UUIDs]]
 deps = ["Random", "SHA"]
@@ -201,15 +235,19 @@ uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [[deps.Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.13+0"
 
 [[deps.libLLVM_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8f36deef-c2a5-5394-99ed-8e07531fb29a"
+version = "14.0.6+3"
 
 [[deps.nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.48.0+0"
 
 [[deps.p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "17.4.0+0"

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -7,6 +7,6 @@ P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"
 
 [compat]
 CEnum = "0.4"
-Clang = "0.15, 0.16.0 - 0.16.5, 0.17" # see https://github.com/JuliaInterop/Clang.jl/issues/405
+Clang = "0.17.7"
 MPI = "0.20"
 P4est_jll = "2.8"

--- a/dev/README.md
+++ b/dev/README.md
@@ -14,9 +14,8 @@ The general process for creating bindings with Clang.jl is as follows:
 9. Despair.
 
 If you want to try this yourself, proceed as follows. The current version of
-the bindings has been generated using Julia v1.7.3; the corresponding
-`Manifest.toml` file is included for reproducibility. Updating everything
-to Julia v1.8.3 was also successful.
+the bindings has been generated using Julia v1.9.3; the corresponding
+`Manifest.toml` file is included for reproducibility.
 
 To generate new bindings, run
 ```shell

--- a/dev/generator.toml
+++ b/dev/generator.toml
@@ -255,6 +255,11 @@ enumerator_comment_style = "outofline"
 # if set to true, C function prototype will be included in documentation
 show_c_function_prototype = true
 
+# if set to true, static functions will be ignored
+# see https://github.com/trixi-framework/P4est.jl/issues/99
+# this needs to come before(!) the `[codegen]` block!
+skip_static_functions = true
+
 [codegen]
 # map C's bool to Julia's Bool instead of `Cuchar` a.k.a `UInt8`.
 use_julia_bool = true

--- a/dev/generator.toml
+++ b/dev/generator.toml
@@ -215,6 +215,10 @@ is_local_header_only = true
 # ```
 smart_de_anonymize = true
 
+# if set to true, static functions will be ignored
+# see https://github.com/trixi-framework/P4est.jl/issues/99
+skip_static_functions = true
+
 # EXPERIMENTAL
 # if this option is set to true, those structs that are not necessary to be an
 # immutable struct will be generated as a mutable struct.
@@ -254,11 +258,6 @@ enumerator_comment_style = "outofline"
 
 # if set to true, C function prototype will be included in documentation
 show_c_function_prototype = true
-
-# if set to true, static functions will be ignored
-# see https://github.com/trixi-framework/P4est.jl/issues/99
-# this needs to come before(!) the `[codegen]` block!
-skip_static_functions = true
 
 [codegen]
 # map C's bool to Julia's Bool instead of `Cuchar` a.k.a `UInt8`.

--- a/src/LibP4est.jl
+++ b/src/LibP4est.jl
@@ -1497,126 +1497,6 @@ function sc_array_pqueue_pop(array, result, compar)
 end
 
 """
-    sc_array_index(array, iz)
-
-### Prototype
-```c
-static inline void * sc_array_index (sc_array_t * array, size_t iz);
-```
-"""
-function sc_array_index(array, iz)
-    @ccall libsc.sc_array_index(array::Ptr{sc_array_t}, iz::Csize_t)::Ptr{Cvoid}
-end
-
-"""
-    sc_array_index_null(array, iz)
-
-### Prototype
-```c
-static inline void * sc_array_index_null (sc_array_t * array, size_t iz);
-```
-"""
-function sc_array_index_null(array, iz)
-    @ccall libsc.sc_array_index_null(array::Ptr{sc_array_t}, iz::Csize_t)::Ptr{Cvoid}
-end
-
-"""
-    sc_array_index_int(array, i)
-
-### Prototype
-```c
-static inline void * sc_array_index_int (sc_array_t * array, int i);
-```
-"""
-function sc_array_index_int(array, i)
-    @ccall libsc.sc_array_index_int(array::Ptr{sc_array_t}, i::Cint)::Ptr{Cvoid}
-end
-
-"""
-    sc_array_index_long(array, l)
-
-### Prototype
-```c
-static inline void * sc_array_index_long (sc_array_t * array, long l);
-```
-"""
-function sc_array_index_long(array, l)
-    @ccall libsc.sc_array_index_long(array::Ptr{sc_array_t}, l::Clong)::Ptr{Cvoid}
-end
-
-"""
-    sc_array_index_ssize_t(array, is)
-
-### Prototype
-```c
-static inline void * sc_array_index_ssize_t (sc_array_t * array, ssize_t is);
-```
-"""
-function sc_array_index_ssize_t(array, is)
-    @ccall libsc.sc_array_index_ssize_t(array::Ptr{sc_array_t}, is::Cssize_t)::Ptr{Cvoid}
-end
-
-"""
-    sc_array_index_int16(array, i16)
-
-### Prototype
-```c
-static inline void * sc_array_index_int16 (sc_array_t * array, int16_t i16);
-```
-"""
-function sc_array_index_int16(array, i16)
-    @ccall libsc.sc_array_index_int16(array::Ptr{sc_array_t}, i16::Int16)::Ptr{Cvoid}
-end
-
-"""
-    sc_array_position(array, element)
-
-### Prototype
-```c
-static inline size_t sc_array_position (sc_array_t * array, void *element);
-```
-"""
-function sc_array_position(array, element)
-    @ccall libsc.sc_array_position(array::Ptr{sc_array_t}, element::Ptr{Cvoid})::Csize_t
-end
-
-"""
-    sc_array_pop(array)
-
-### Prototype
-```c
-static inline void * sc_array_pop (sc_array_t * array);
-```
-"""
-function sc_array_pop(array)
-    @ccall libsc.sc_array_pop(array::Ptr{sc_array_t})::Ptr{Cvoid}
-end
-
-"""
-    sc_array_push_count(array, add_count)
-
-### Prototype
-```c
-static inline void * sc_array_push_count (sc_array_t * array, size_t add_count);
-```
-"""
-function sc_array_push_count(array, add_count)
-    @ccall libsc.sc_array_push_count(array::Ptr{sc_array_t}, add_count::Csize_t)::Ptr{Cvoid}
-end
-
-"""
-    sc_array_push(array)
-
-### Prototype
-```c
-static inline void * sc_array_push (sc_array_t * array);
-```
-"""
-function sc_array_push(array)
-    @ccall libsc.sc_array_push(array::Ptr{sc_array_t})::Ptr{Cvoid}
-end
-
-"""
     sc_mstamp
 
 A data container to create memory items of the same size. Allocations are bundled so it's fast for small memory sizes. The items created will remain valid until the container is destroyed. There is no option to return an item to the container. See sc_mempool_t for that purpose.
@@ -1773,7 +1653,7 @@ end
 """
     sc_mempool_new(elem_size)
 
-Creates a new mempool structure with the zero\\_and\\_persist option off. The contents of any elements returned by [`sc_mempool_alloc`](@ref) are undefined.
+Creates a new mempool structure with the zero\\_and\\_persist option off. The contents of any elements returned by sc\\_mempool\\_alloc are undefined.
 
 ### Parameters
 * `elem_size`:\\[in\\] Size of one element in bytes.
@@ -1878,30 +1758,6 @@ void sc_mempool_truncate (sc_mempool_t * mempool);
 """
 function sc_mempool_truncate(mempool)
     @ccall libsc.sc_mempool_truncate(mempool::Ptr{sc_mempool_t})::Cvoid
-end
-
-"""
-    sc_mempool_alloc(mempool)
-
-### Prototype
-```c
-static inline void * sc_mempool_alloc (sc_mempool_t * mempool);
-```
-"""
-function sc_mempool_alloc(mempool)
-    @ccall libsc.sc_mempool_alloc(mempool::Ptr{sc_mempool_t})::Ptr{Cvoid}
-end
-
-"""
-    sc_mempool_free(mempool, elem)
-
-### Prototype
-```c
-static inline void sc_mempool_free (sc_mempool_t * mempool, void *elem);
-```
-"""
-function sc_mempool_free(mempool, elem)
-    @ccall libsc.sc_mempool_free(mempool::Ptr{sc_mempool_t}, elem::Ptr{Cvoid})::Cvoid
 end
 
 """
@@ -3104,32 +2960,6 @@ end
 """Tags for MPI messages"""
 const p4est_comm_tag_t = p4est_comm_tag
 
-# no prototype is found for this function at p4est_base.h:325:1, please use with caution
-"""
-    p4est_log_indent_push()
-
-### Prototype
-```c
-static inline void p4est_log_indent_push ();
-```
-"""
-function p4est_log_indent_push()
-    @ccall libp4est.p4est_log_indent_push()::Cvoid
-end
-
-# no prototype is found for this function at p4est_base.h:331:1, please use with caution
-"""
-    p4est_log_indent_pop()
-
-### Prototype
-```c
-static inline void p4est_log_indent_pop ();
-```
-"""
-function p4est_log_indent_pop()
-    @ccall libp4est.p4est_log_indent_pop()::Cvoid
-end
-
 """
     p4est_init(log_handler, log_threshold)
 
@@ -3142,90 +2972,6 @@ void p4est_init (sc_log_handler_t log_handler, int log_threshold);
 """
 function p4est_init(log_handler, log_threshold)
     @ccall libp4est.p4est_init(log_handler::sc_log_handler_t, log_threshold::Cint)::Cvoid
-end
-
-"""
-    p4est_topidx_hash2(tt)
-
-### Prototype
-```c
-static inline unsigned p4est_topidx_hash2 (const p4est_topidx_t * tt);
-```
-"""
-function p4est_topidx_hash2(tt)
-    @ccall libp4est.p4est_topidx_hash2(tt::Ptr{p4est_topidx_t})::Cuint
-end
-
-"""
-    p4est_topidx_hash3(tt)
-
-### Prototype
-```c
-static inline unsigned p4est_topidx_hash3 (const p4est_topidx_t * tt);
-```
-"""
-function p4est_topidx_hash3(tt)
-    @ccall libp4est.p4est_topidx_hash3(tt::Ptr{p4est_topidx_t})::Cuint
-end
-
-"""
-    p4est_topidx_hash4(tt)
-
-### Prototype
-```c
-static inline unsigned p4est_topidx_hash4 (const p4est_topidx_t * tt);
-```
-"""
-function p4est_topidx_hash4(tt)
-    @ccall libp4est.p4est_topidx_hash4(tt::Ptr{p4est_topidx_t})::Cuint
-end
-
-"""
-    p4est_topidx_is_sorted(t, length)
-
-### Prototype
-```c
-static inline int p4est_topidx_is_sorted (p4est_topidx_t * t, int length);
-```
-"""
-function p4est_topidx_is_sorted(t, length)
-    @ccall libp4est.p4est_topidx_is_sorted(t::Ptr{p4est_topidx_t}, length::Cint)::Cint
-end
-
-"""
-    p4est_topidx_bsort(t, length)
-
-### Prototype
-```c
-static inline void p4est_topidx_bsort (p4est_topidx_t * t, int length);
-```
-"""
-function p4est_topidx_bsort(t, length)
-    @ccall libp4est.p4est_topidx_bsort(t::Ptr{p4est_topidx_t}, length::Cint)::Cvoid
-end
-
-"""
-    p4est_partition_cut_uint64(global_num, p, num_procs)
-
-### Prototype
-```c
-static inline uint64_t p4est_partition_cut_uint64 (uint64_t global_num, int p, int num_procs);
-```
-"""
-function p4est_partition_cut_uint64(global_num, p, num_procs)
-    @ccall libp4est.p4est_partition_cut_uint64(global_num::UInt64, p::Cint, num_procs::Cint)::UInt64
-end
-
-"""
-    p4est_partition_cut_gloidx(global_num, p, num_procs)
-
-### Prototype
-```c
-static inline p4est_gloidx_t p4est_partition_cut_gloidx (p4est_gloidx_t global_num, int p, int num_procs);
-```
-"""
-function p4est_partition_cut_gloidx(global_num, p, num_procs)
-    @ccall libp4est.p4est_partition_cut_gloidx(global_num::p4est_gloidx_t, p::Cint, num_procs::Cint)::p4est_gloidx_t
 end
 
 """
@@ -3438,11 +3184,13 @@ end
 
 Transform a face corner across one of the adjacent faces into a neighbor tree. This version expects the neighbor face and orientation separately.
 
+`.`
+
 ### Parameters
 * `fc`:\\[in\\] A face corner number in 0..1.
 * `f`:\\[in\\] A face that the face corner number *fc* is relative to.
 * `nf`:\\[in\\] A neighbor face that is on the other side of .
-* `o`:\\[in\\] The orientation between tree boundary faces *f* and .
+* `o`:\\[in\\] The orientation between tree boundary faces *f* and
 ### Returns
 The face corner number relative to the neighbor's face.
 ### Prototype
@@ -3459,11 +3207,13 @@ end
 
 Transform a corner across one of the adjacent faces into a neighbor tree. This version expects the neighbor face and orientation separately.
 
+`.`
+
 ### Parameters
 * `c`:\\[in\\] A corner number in 0..3.
 * `f`:\\[in\\] A face number that touches the corner *c*.
 * `nf`:\\[in\\] A neighbor face that is on the other side of .
-* `o`:\\[in\\] The orientation between tree boundary faces *f* and .
+* `o`:\\[in\\] The orientation between tree boundary faces *f* and
 ### Returns
 The number of the corner seen from the neighbor tree.
 ### Prototype
@@ -4134,18 +3884,6 @@ function p4est_connectivity_is_equivalent(conn1, conn2)
 end
 
 """
-    p4est_corner_array_index(array, it)
-
-### Prototype
-```c
-static inline p4est_corner_transform_t * p4est_corner_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p4est_corner_array_index(array, it)
-    @ccall libp4est.p4est_corner_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p4est_corner_transform_t}
-end
-
-"""
     p4est_connectivity_read_inp_stream(stream, num_vertices, num_trees, vertices, tree_to_vertex)
 
 Read an ABAQUS input file from a file stream.
@@ -4697,66 +4435,6 @@ p4est_t *p4est_load (const char *filename, sc_MPI_Comm mpicomm, size_t data_size
 """
 function p4est_load(filename, mpicomm, data_size, load_data, user_pointer, connectivity)
     @ccall libp4est.p4est_load(filename::Cstring, mpicomm::MPI_Comm, data_size::Csize_t, load_data::Cint, user_pointer::Ptr{Cvoid}, connectivity::Ptr{Ptr{p4est_connectivity_t}})::Ptr{p4est_t}
-end
-
-"""
-    p4est_tree_array_index(array, it)
-
-### Prototype
-```c
-static inline p4est_tree_t * p4est_tree_array_index (sc_array_t * array, p4est_topidx_t it);
-```
-"""
-function p4est_tree_array_index(array, it)
-    @ccall libp4est.p4est_tree_array_index(array::Ptr{sc_array_t}, it::p4est_topidx_t)::Ptr{p4est_tree_t}
-end
-
-"""
-    p4est_quadrant_array_index(array, it)
-
-### Prototype
-```c
-static inline p4est_quadrant_t * p4est_quadrant_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p4est_quadrant_array_index(array, it)
-    @ccall libp4est.p4est_quadrant_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p4est_quadrant_t}
-end
-
-"""
-    p4est_quadrant_array_push(array)
-
-### Prototype
-```c
-static inline p4est_quadrant_t * p4est_quadrant_array_push (sc_array_t * array);
-```
-"""
-function p4est_quadrant_array_push(array)
-    @ccall libp4est.p4est_quadrant_array_push(array::Ptr{sc_array_t})::Ptr{p4est_quadrant_t}
-end
-
-"""
-    p4est_quadrant_mempool_alloc(mempool)
-
-### Prototype
-```c
-static inline p4est_quadrant_t * p4est_quadrant_mempool_alloc (sc_mempool_t * mempool);
-```
-"""
-function p4est_quadrant_mempool_alloc(mempool)
-    @ccall libp4est.p4est_quadrant_mempool_alloc(mempool::Ptr{sc_mempool_t})::Ptr{p4est_quadrant_t}
-end
-
-"""
-    p4est_quadrant_list_pop(list)
-
-### Prototype
-```c
-static inline p4est_quadrant_t * p4est_quadrant_list_pop (sc_list_t * list);
-```
-"""
-function p4est_quadrant_list_pop(list)
-    @ccall libp4est.p4est_quadrant_list_pop(list::Ptr{sc_list_t})::Ptr{p4est_quadrant_t}
 end
 
 """
@@ -5738,54 +5416,6 @@ function p4est_iterate(p4est_, ghost_layer, user_data, iter_volume, iter_face, i
     @ccall libp4est.p4est_iterate(p4est_::Ptr{p4est_t}, ghost_layer::Ptr{p4est_ghost_t}, user_data::Ptr{Cvoid}, iter_volume::p4est_iter_volume_t, iter_face::p4est_iter_face_t, iter_corner::p4est_iter_corner_t)::Cvoid
 end
 
-"""
-    p4est_iter_cside_array_index_int(array, it)
-
-### Prototype
-```c
-static inline p4est_iter_corner_side_t * p4est_iter_cside_array_index_int (sc_array_t * array, int it);
-```
-"""
-function p4est_iter_cside_array_index_int(array, it)
-    @ccall libp4est.p4est_iter_cside_array_index_int(array::Ptr{sc_array_t}, it::Cint)::Ptr{p4est_iter_corner_side_t}
-end
-
-"""
-    p4est_iter_cside_array_index(array, it)
-
-### Prototype
-```c
-static inline p4est_iter_corner_side_t * p4est_iter_cside_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p4est_iter_cside_array_index(array, it)
-    @ccall libp4est.p4est_iter_cside_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p4est_iter_corner_side_t}
-end
-
-"""
-    p4est_iter_fside_array_index_int(array, it)
-
-### Prototype
-```c
-static inline p4est_iter_face_side_t * p4est_iter_fside_array_index_int (sc_array_t * array, int it);
-```
-"""
-function p4est_iter_fside_array_index_int(array, it)
-    @ccall libp4est.p4est_iter_fside_array_index_int(array::Ptr{sc_array_t}, it::Cint)::Ptr{p4est_iter_face_side_t}
-end
-
-"""
-    p4est_iter_fside_array_index(array, it)
-
-### Prototype
-```c
-static inline p4est_iter_face_side_t * p4est_iter_fside_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p4est_iter_fside_array_index(array, it)
-    @ccall libp4est.p4est_iter_fside_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p4est_iter_face_side_t}
-end
-
 const p4est_lnodes_code_t = Int8
 
 struct p4est_lnodes
@@ -5812,7 +5442,7 @@ f\\_3 c\\_2 c\\_3 6---7---8 | | f\\_0 3 4 5 f\\_1 | | 0---1---2 c\\_0 c\\_1 f\\_
 
 element\\_nodes indexes into the set of local nodes, layed out as follows: local nodes = [<-----owned\\_count----->|<-----nonlocal\\_nodes----->] = [<----------------num\\_local\\_nodes----------------->] nonlocal\\_nodes contains the globally unique numbers for independent nodes that are owned by other processes; for local nodes, the globally unique numbers are given by i + global\\_offset, where i is the local number. Hanging nodes are always local and don't have a global number. They index the geometrically corresponding independent nodes of a neighbor.
 
-Whether nodes are hanging or not is decided based on the element faces. This information is encoded in face\\_code with one int8\\_t per element. If no faces are hanging, the value is zero, otherwise the face\\_code is interpreted by [`p4est_lnodes_decode`](@ref).
+Whether nodes are hanging or not is decided based on the element faces. This information is encoded in face\\_code with one int8\\_t per element. If no faces are hanging, the value is zero, otherwise the face\\_code is interpreted by p4est\\_lnodes\\_decode.
 
 Independent nodes can be shared by multiple MPI ranks. The owner rank of a node is the one from the lowest numbered element on the lowest numbered octree *touching* the node.
 
@@ -5860,18 +5490,6 @@ The structure stored in the sharers array.
 shared\\_nodes is a sorted array of [`p4est_locidx_t`](@ref) that indexes into local nodes. The shared\\_nodes array has a contiguous (or empty) section of nodes owned by the current rank. shared\\_mine\\_offset and shared\\_mine\\_count identify this section by indexing the shared\\_nodes array, not the local nodes array. owned\\_offset and owned\\_count define the section of local nodes that is owned by the listed rank (the section may be empty). For the current process these coincide with those in [`p4est_lnodes_t`](@ref).
 """
 const p4est_lnodes_rank_t = p4est_lnodes_rank
-
-"""
-    p4est_lnodes_decode(face_code, hanging_face)
-
-### Prototype
-```c
-static inline int p4est_lnodes_decode (p4est_lnodes_code_t face_code, int hanging_face[4]);
-```
-"""
-function p4est_lnodes_decode(face_code, hanging_face)
-    @ccall libp4est.p4est_lnodes_decode(face_code::p4est_lnodes_code_t, hanging_face::Ptr{Cint})::Cint
-end
 
 """
     p4est_lnodes_new(p4est_, ghost_layer, degree)
@@ -6090,42 +5708,6 @@ void p4est_lnodes_buffer_destroy (p4est_lnodes_buffer_t * buffer);
 """
 function p4est_lnodes_buffer_destroy(buffer)
     @ccall libp4est.p4est_lnodes_buffer_destroy(buffer::Ptr{p4est_lnodes_buffer_t})::Cvoid
-end
-
-"""
-    p4est_lnodes_rank_array_index_int(array, it)
-
-### Prototype
-```c
-static inline p4est_lnodes_rank_t * p4est_lnodes_rank_array_index_int (sc_array_t * array, int it);
-```
-"""
-function p4est_lnodes_rank_array_index_int(array, it)
-    @ccall libp4est.p4est_lnodes_rank_array_index_int(array::Ptr{sc_array_t}, it::Cint)::Ptr{p4est_lnodes_rank_t}
-end
-
-"""
-    p4est_lnodes_rank_array_index(array, it)
-
-### Prototype
-```c
-static inline p4est_lnodes_rank_t * p4est_lnodes_rank_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p4est_lnodes_rank_array_index(array, it)
-    @ccall libp4est.p4est_lnodes_rank_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p4est_lnodes_rank_t}
-end
-
-"""
-    p4est_lnodes_global_index(lnodes, lidx)
-
-### Prototype
-```c
-static inline p4est_gloidx_t p4est_lnodes_global_index (p4est_lnodes_t * lnodes, p4est_locidx_t lidx);
-```
-"""
-function p4est_lnodes_global_index(lnodes, lidx)
-    @ccall libp4est.p4est_lnodes_global_index(lnodes::Ptr{p4est_lnodes_t}, lidx::p4est_locidx_t)::p4est_gloidx_t
 end
 
 """A datatype to handle the linear id in 2D."""
@@ -7363,11 +6945,13 @@ end
 
 Transform a face corner across one of the adjacent faces into a neighbor tree. This version expects the neighbor face and orientation separately.
 
+`.`
+
 ### Parameters
 * `fc`:\\[in\\] A face corner number in 0..3.
 * `f`:\\[in\\] A face that the face corner *fc* is relative to.
 * `nf`:\\[in\\] A neighbor face that is on the other side of .
-* `o`:\\[in\\] The orientation between tree boundary faces *f* and .
+* `o`:\\[in\\] The orientation between tree boundary faces *f* and
 ### Returns
 The face corner number relative to the neighbor's face.
 ### Prototype
@@ -7384,11 +6968,13 @@ end
 
 Transform a corner across one of the adjacent faces into a neighbor tree. This version expects the neighbor face and orientation separately.
 
+`.`
+
 ### Parameters
 * `c`:\\[in\\] A corner number in 0..7.
 * `f`:\\[in\\] A face number that touches the corner *c*.
 * `nf`:\\[in\\] A neighbor face that is on the other side of .
-* `o`:\\[in\\] The orientation between tree boundary faces *f* and .
+* `o`:\\[in\\] The orientation between tree boundary faces *f* and
 ### Returns
 The number of the corner seen from the neighbor tree.
 ### Prototype
@@ -7405,11 +6991,13 @@ end
 
 Transform a face-edge across one of the adjacent faces into a neighbor tree. This version expects the neighbor face and orientation separately.
 
+`.`
+
 ### Parameters
 * `fe`:\\[in\\] A face edge number in 0..3.
 * `f`:\\[in\\] A face number that touches the edge *e*.
 * `nf`:\\[in\\] A neighbor face that is on the other side of .
-* `o`:\\[in\\] The orientation between tree boundary faces *f* and .
+* `o`:\\[in\\] The orientation between tree boundary faces *f* and
 ### Returns
 The face edge number seen from the neighbor tree.
 ### Prototype
@@ -7426,11 +7014,13 @@ end
 
 Transform an edge across one of the adjacent faces into a neighbor tree. This version expects the neighbor face and orientation separately.
 
+`.`
+
 ### Parameters
 * `e`:\\[in\\] A edge number in 0..11.
 * `f`:\\[in\\] A face 0..5 that touches the edge *e*.
 * `nf`:\\[in\\] A neighbor face that is on the other side of .
-* `o`:\\[in\\] The orientation between tree boundary faces *f* and .
+* `o`:\\[in\\] The orientation between tree boundary faces *f* and
 ### Returns
 The edge's number seen from the neighbor.
 ### Prototype
@@ -8078,30 +7668,6 @@ int p8est_connectivity_is_equivalent (p8est_connectivity_t * conn1, p8est_connec
 """
 function p8est_connectivity_is_equivalent(conn1, conn2)
     @ccall libp4est.p8est_connectivity_is_equivalent(conn1::Ptr{p8est_connectivity_t}, conn2::Ptr{p8est_connectivity_t})::Cint
-end
-
-"""
-    p8est_edge_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_edge_transform_t * p8est_edge_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p8est_edge_array_index(array, it)
-    @ccall libp4est.p8est_edge_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p8est_edge_transform_t}
-end
-
-"""
-    p8est_corner_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_corner_transform_t * p8est_corner_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p8est_corner_array_index(array, it)
-    @ccall libp4est.p8est_corner_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p8est_corner_transform_t}
 end
 
 """
@@ -8784,78 +8350,6 @@ p6est_t *p6est_load (const char *filename, sc_MPI_Comm mpicomm, size_t data_size
 """
 function p6est_load(filename, mpicomm, data_size, load_data, user_pointer, connectivity)
     @ccall libp4est.p6est_load(filename::Cstring, mpicomm::MPI_Comm, data_size::Csize_t, load_data::Cint, user_pointer::Ptr{Cvoid}, connectivity::Ptr{Ptr{p6est_connectivity_t}})::Ptr{p6est_t}
-end
-
-"""
-    p2est_quadrant_array_index(array, it)
-
-### Prototype
-```c
-static inline p2est_quadrant_t * p2est_quadrant_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p2est_quadrant_array_index(array, it)
-    @ccall libp4est.p2est_quadrant_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p2est_quadrant_t}
-end
-
-"""
-    p2est_quadrant_array_push(array)
-
-### Prototype
-```c
-static inline p2est_quadrant_t * p2est_quadrant_array_push (sc_array_t * array);
-```
-"""
-function p2est_quadrant_array_push(array)
-    @ccall libp4est.p2est_quadrant_array_push(array::Ptr{sc_array_t})::Ptr{p2est_quadrant_t}
-end
-
-"""
-    p2est_quadrant_mempool_alloc(mempool)
-
-### Prototype
-```c
-static inline p2est_quadrant_t * p2est_quadrant_mempool_alloc (sc_mempool_t * mempool);
-```
-"""
-function p2est_quadrant_mempool_alloc(mempool)
-    @ccall libp4est.p2est_quadrant_mempool_alloc(mempool::Ptr{sc_mempool_t})::Ptr{p2est_quadrant_t}
-end
-
-"""
-    p2est_quadrant_list_pop(list)
-
-### Prototype
-```c
-static inline p2est_quadrant_t * p2est_quadrant_list_pop (sc_list_t * list);
-```
-"""
-function p2est_quadrant_list_pop(list)
-    @ccall libp4est.p2est_quadrant_list_pop(list::Ptr{sc_list_t})::Ptr{p2est_quadrant_t}
-end
-
-"""
-    p6est_layer_init_data(p6est_, which_tree, column, layer, init_fn)
-
-### Prototype
-```c
-static inline void p6est_layer_init_data (p6est_t * p6est, p4est_topidx_t which_tree, p4est_quadrant_t * column, p2est_quadrant_t * layer, p6est_init_t init_fn);
-```
-"""
-function p6est_layer_init_data(p6est_, which_tree, column, layer, init_fn)
-    @ccall libp4est.p6est_layer_init_data(p6est_::Ptr{p6est_t}, which_tree::p4est_topidx_t, column::Ptr{p4est_quadrant_t}, layer::Ptr{p2est_quadrant_t}, init_fn::p6est_init_t)::Cvoid
-end
-
-"""
-    p6est_layer_free_data(p6est_, layer)
-
-### Prototype
-```c
-static inline void p6est_layer_free_data (p6est_t * p6est, p2est_quadrant_t * layer);
-```
-"""
-function p6est_layer_free_data(p6est_, layer)
-    @ccall libp4est.p6est_layer_free_data(p6est_::Ptr{p6est_t}, layer::Ptr{p2est_quadrant_t})::Cvoid
 end
 
 """
@@ -9583,66 +9077,6 @@ p8est_t *p8est_load (const char *filename, sc_MPI_Comm mpicomm, size_t data_size
 """
 function p8est_load(filename, mpicomm, data_size, load_data, user_pointer, connectivity)
     @ccall libp4est.p8est_load(filename::Cstring, mpicomm::MPI_Comm, data_size::Csize_t, load_data::Cint, user_pointer::Ptr{Cvoid}, connectivity::Ptr{Ptr{p8est_connectivity_t}})::Ptr{p8est_t}
-end
-
-"""
-    p8est_tree_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_tree_t * p8est_tree_array_index (sc_array_t * array, p4est_topidx_t it);
-```
-"""
-function p8est_tree_array_index(array, it)
-    @ccall libp4est.p8est_tree_array_index(array::Ptr{sc_array_t}, it::p4est_topidx_t)::Ptr{p8est_tree_t}
-end
-
-"""
-    p8est_quadrant_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_quadrant_t * p8est_quadrant_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p8est_quadrant_array_index(array, it)
-    @ccall libp4est.p8est_quadrant_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p8est_quadrant_t}
-end
-
-"""
-    p8est_quadrant_array_push(array)
-
-### Prototype
-```c
-static inline p8est_quadrant_t * p8est_quadrant_array_push (sc_array_t * array);
-```
-"""
-function p8est_quadrant_array_push(array)
-    @ccall libp4est.p8est_quadrant_array_push(array::Ptr{sc_array_t})::Ptr{p8est_quadrant_t}
-end
-
-"""
-    p8est_quadrant_mempool_alloc(mempool)
-
-### Prototype
-```c
-static inline p8est_quadrant_t * p8est_quadrant_mempool_alloc (sc_mempool_t * mempool);
-```
-"""
-function p8est_quadrant_mempool_alloc(mempool)
-    @ccall libp4est.p8est_quadrant_mempool_alloc(mempool::Ptr{sc_mempool_t})::Ptr{p8est_quadrant_t}
-end
-
-"""
-    p8est_quadrant_list_pop(list)
-
-### Prototype
-```c
-static inline p8est_quadrant_t * p8est_quadrant_list_pop (sc_list_t * list);
-```
-"""
-function p8est_quadrant_list_pop(list)
-    @ccall libp4est.p8est_quadrant_list_pop(list::Ptr{sc_list_t})::Ptr{p8est_quadrant_t}
 end
 
 """
@@ -10720,78 +10154,6 @@ function p8est_iterate(p4est_, ghost_layer, user_data, iter_volume, iter_face, i
     @ccall libp4est.p8est_iterate(p4est_::Ptr{p8est_t}, ghost_layer::Ptr{p8est_ghost_t}, user_data::Ptr{Cvoid}, iter_volume::p8est_iter_volume_t, iter_face::p8est_iter_face_t, iter_edge::p8est_iter_edge_t, iter_corner::p8est_iter_corner_t)::Cvoid
 end
 
-"""
-    p8est_iter_cside_array_index_int(array, it)
-
-### Prototype
-```c
-static inline p8est_iter_corner_side_t * p8est_iter_cside_array_index_int (sc_array_t * array, int it);
-```
-"""
-function p8est_iter_cside_array_index_int(array, it)
-    @ccall libp4est.p8est_iter_cside_array_index_int(array::Ptr{sc_array_t}, it::Cint)::Ptr{p8est_iter_corner_side_t}
-end
-
-"""
-    p8est_iter_cside_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_iter_corner_side_t * p8est_iter_cside_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p8est_iter_cside_array_index(array, it)
-    @ccall libp4est.p8est_iter_cside_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p8est_iter_corner_side_t}
-end
-
-"""
-    p8est_iter_eside_array_index_int(array, it)
-
-### Prototype
-```c
-static inline p8est_iter_edge_side_t * p8est_iter_eside_array_index_int (sc_array_t * array, int it);
-```
-"""
-function p8est_iter_eside_array_index_int(array, it)
-    @ccall libp4est.p8est_iter_eside_array_index_int(array::Ptr{sc_array_t}, it::Cint)::Ptr{p8est_iter_edge_side_t}
-end
-
-"""
-    p8est_iter_eside_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_iter_edge_side_t * p8est_iter_eside_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p8est_iter_eside_array_index(array, it)
-    @ccall libp4est.p8est_iter_eside_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p8est_iter_edge_side_t}
-end
-
-"""
-    p8est_iter_fside_array_index_int(array, it)
-
-### Prototype
-```c
-static inline p8est_iter_face_side_t * p8est_iter_fside_array_index_int (sc_array_t * array, int it);
-```
-"""
-function p8est_iter_fside_array_index_int(array, it)
-    @ccall libp4est.p8est_iter_fside_array_index_int(array::Ptr{sc_array_t}, it::Cint)::Ptr{p8est_iter_face_side_t}
-end
-
-"""
-    p8est_iter_fside_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_iter_face_side_t * p8est_iter_fside_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p8est_iter_fside_array_index(array, it)
-    @ccall libp4est.p8est_iter_fside_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p8est_iter_face_side_t}
-end
-
 const p8est_lnodes_code_t = Int16
 
 struct p8est_lnodes
@@ -10814,7 +10176,7 @@ Store a parallel numbering of Lobatto points of a given degree > 0.
 
 Each element has degree+1 nodes per edge and vnodes = (degree+1)^3 nodes per volume. element\\_nodes is of dimension vnodes * num\\_local\\_elements and lists the nodes of each element in lexicographic yx-order (x varies fastest); element\\_nodes indexes into the set of local nodes, layed out as follows: local nodes = [<-----owned\\_count----->|<-----nonlocal\\_nodes----->] = [<----------------num\\_local\\_nodes----------------->] nonlocal\\_nodes contains the globally unique numbers for independent nodes that are owned by other processes; for local nodes, the globally unique numbers are given by i + global\\_offset, where i is the local number. Hanging nodes are always local and don't have a global number. They index the geometrically corresponding independent nodes of a neighbor.
 
-Whether nodes are hanging or not is decided based on the element faces and edges. This information is encoded in face\\_code with one int16\\_t per element. If no faces or edges are hanging, the value is zero, otherwise the face\\_code is interpreted by [`p8est_lnodes_decode`](@ref).
+Whether nodes are hanging or not is decided based on the element faces and edges. This information is encoded in face\\_code with one int16\\_t per element. If no faces or edges are hanging, the value is zero, otherwise the face\\_code is interpreted by p8est\\_lnodes\\_decode.
 
 Independent nodes can be shared by multiple MPI ranks. The owner rank of a node is the one from the lowest numbered element on the lowest numbered octree *touching* the node.
 
@@ -10860,18 +10222,6 @@ The structure stored in the sharers array.
 shared\\_nodes is a sorted array of [`p4est_locidx_t`](@ref) that indexes into local nodes. The shared\\_nodes array has a contiguous (or empty) section of nodes owned by the current rank. shared\\_mine\\_offset and shared\\_mine\\_count identify this section by indexing the shared\\_nodes array, not the local nodes array. owned\\_offset and owned\\_count define the section of local nodes that is owned by the listed rank (the section may be empty). For the current process these coincide with those in [`p8est_lnodes_t`](@ref).
 """
 const p8est_lnodes_rank_t = p8est_lnodes_rank
-
-"""
-    p8est_lnodes_decode(face_code, hanging_face, hanging_edge)
-
-### Prototype
-```c
-static inline int p8est_lnodes_decode (p8est_lnodes_code_t face_code, int hanging_face[6], int hanging_edge[12]);
-```
-"""
-function p8est_lnodes_decode(face_code, hanging_face, hanging_edge)
-    @ccall libp4est.p8est_lnodes_decode(face_code::p8est_lnodes_code_t, hanging_face::Ptr{Cint}, hanging_edge::Ptr{Cint})::Cint
-end
 
 """
     p8est_lnodes_new(p8est_, ghost_layer, degree)
@@ -11090,42 +10440,6 @@ void p8est_lnodes_buffer_destroy (p8est_lnodes_buffer_t * buffer);
 """
 function p8est_lnodes_buffer_destroy(buffer)
     @ccall libp4est.p8est_lnodes_buffer_destroy(buffer::Ptr{p8est_lnodes_buffer_t})::Cvoid
-end
-
-"""
-    p8est_lnodes_rank_array_index_int(array, it)
-
-### Prototype
-```c
-static inline p8est_lnodes_rank_t * p8est_lnodes_rank_array_index_int (sc_array_t * array, int it);
-```
-"""
-function p8est_lnodes_rank_array_index_int(array, it)
-    @ccall libp4est.p8est_lnodes_rank_array_index_int(array::Ptr{sc_array_t}, it::Cint)::Ptr{p8est_lnodes_rank_t}
-end
-
-"""
-    p8est_lnodes_rank_array_index(array, it)
-
-### Prototype
-```c
-static inline p8est_lnodes_rank_t * p8est_lnodes_rank_array_index (sc_array_t * array, size_t it);
-```
-"""
-function p8est_lnodes_rank_array_index(array, it)
-    @ccall libp4est.p8est_lnodes_rank_array_index(array::Ptr{sc_array_t}, it::Csize_t)::Ptr{p8est_lnodes_rank_t}
-end
-
-"""
-    p8est_lnodes_global_index(lnodes, lidx)
-
-### Prototype
-```c
-static inline p4est_gloidx_t p8est_lnodes_global_index (p8est_lnodes_t * lnodes, p4est_locidx_t lidx);
-```
-"""
-function p8est_lnodes_global_index(lnodes, lidx)
-    @ccall libp4est.p8est_lnodes_global_index(lnodes::Ptr{p8est_lnodes_t}, lidx::p4est_locidx_t)::p4est_gloidx_t
 end
 
 """


### PR DESCRIPTION
As noted in https://github.com/trixi-framework/P4est.jl/issues/99, calling static functions from P4est.jl is not possible. In Clang.jl v0.17.7, there exists the option to skip these static functions.