### PR TITLE
Downgrade action moved

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -50,9 +50,10 @@ jobs:
           arch: ${{ matrix.arch }}
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
       - uses: julia-actions/cache@v1
-      - uses: cjdoris/julia-downgrade-compat-action@v1.0.7
+      - uses: julia-actions/julia-downgrade-compat@v1
         with:
           skip: UUIDs
+          projects: ., test
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ""

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -5,5 +5,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 MPI = "0.20"
-MPIPreferences = "0.1"
+MPIPreferences = "0.1.3"
 Test = "1"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,3 +6,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 MPI = "0.20"
 MPIPreferences = "0.1"
+Test = "1"


### PR DESCRIPTION
The downgrade CI action moved to the [julia-action org](https://github.com/julia-actions/julia-downgrade-compat). With version v1.1.0 it also allows to downgrade the `test/Project.toml`.