### PR TITLE
Use default `arch` in CI

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -27,9 +27,9 @@ jobs:
   downgrade_test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     # We could also include the Julia version as in
-    # name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    # name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ github.event_name }}
     # to be more specific. However, that requires us updating the required CI tests whenever we update Julia.
-    name: Downgrade ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Downgrade ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -40,14 +40,11 @@ jobs:
           # - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-downgrade-compat@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,6 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
         JULIA_P4EST_TEST:
           - P4EST_JLL_MPI_DEFAULT
           - P4EST_CUSTOM_MPI_CUSTOM
@@ -97,7 +95,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
           show-versioninfo: true
       - uses: julia-actions/cache@v2
       - name: Install custom MPI library for testing
@@ -139,7 +136,7 @@ jobs:
       # - uses: coverallsapp/github-action@master
       #   with:
       #     github-token: ${{ secrets.GITHUB_TOKEN }}
-      #     flag-name: run-${{ matrix.JULIA_P4EST_TEST }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ github.run_id }}
+      #     flag-name: run-${{ join(matrix.*, '-') }}
       #     parallel: true
       #     path-to-lcov: ./lcov.info
       # Instead, we use a more tedious approach:
@@ -148,11 +145,11 @@ jobs:
       # - Upload only the merged coverage report to Coveralls
       - shell: bash
         run: |
-          cp ./lcov.info ./lcov-${{ matrix.JULIA_P4EST_TEST }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
+          cp ./lcov.info ./lcov-${{ matrix.JULIA_P4EST_TEST }}-${{ matrix.os }}-${{ matrix.version }}.info
       - uses: actions/upload-artifact@v4
         with:
-          name: lcov-${{ matrix.JULIA_P4EST_TEST }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}
-          path: ./lcov-${{ matrix.JULIA_P4EST_TEST }}-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}.info
+          name: lcov-${{ matrix.JULIA_P4EST_TEST }}-${{ matrix.os }}-${{ matrix.version }}
+          path: ./lcov-${{ matrix.JULIA_P4EST_TEST }}-${{ matrix.os }}-${{ matrix.version }}.info
 
   finish:
     needs: test


### PR DESCRIPTION
There are warnings (e.g., https://github.com/trixi-framework/P4est.jl/actions/runs/12108765313) in the CI runs because we request x64 on a macOS runner with arm64. I propose to simply use the default architecture, i.e. to remove the `arch` argument.