### PR TITLE
let CompatHelper track jlls

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}  # optional
-        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs=["", "docs", "test"])'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; subdirs=["", "docs", "test"], include_jll = true)'


### PR DESCRIPTION
We fixed the version of P4est_jll.jl in #104 to avoid errors caused by broken jll builds. However, CompatHelper does not track jlls by default. Thus, I updated the setting accordingly.