### PR TITLE
Use JuliaFormatter.jl version v1.0.60

### DIFF
--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   format-suggestions:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v4
-    - uses: julia-actions/julia-format@v4
-      with:
-      version: "1.0.60"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/julia-format@v4
+        with:
+          version: "1.0.60"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,4 +1,4 @@
-name: format-check
+name: Format suggestions
 
 on:
   push:
@@ -8,31 +8,10 @@ on:
   pull_request:
 
 jobs:
-  check-format:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        julia-version: [1]
-        julia-arch: [x86]
-        os: [ubuntu-latest]
-    steps:
-      - uses: julia-actions/setup-julia@latest
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: actions/checkout@v4
-      - uses: julia-actions/cache@v2
-      - name: Install JuliaFormatter and format
-        run: |
-          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter"))'
-          julia  -e 'using JuliaFormatter; format(["src/P4est.jl", "src/pointerwrappers.jl", "test"])'
-      - name: Format check
-        run: |
-          julia -e '
-          out = Cmd(`git diff --name-only`) |> read |> String
-          if out == ""
-              exit(0)
-          else
-              @error "Some files have not been formatted !!!"
-              write(stdout, out)
-              exit(1)
-          end'
+  format-suggestions:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: julia-actions/julia-format@v4
+      with:
+      version: "1.0.60"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,4 +1,4 @@
-name: Format suggestions
+name: format-check
 
 on:
   push:
@@ -8,10 +8,31 @@ on:
   pull_request:
 
 jobs:
-  format-suggestions:
-    runs-on: ubuntu-latest
+  check-format:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        julia-version: [1]
+        julia-arch: [x86]
+        os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
-      - uses: julia-actions/julia-format@v4
+      - uses: julia-actions/setup-julia@latest
         with:
-          version: "1.0.60"
+          version: ${{ matrix.julia-version }}
+      - uses: actions/checkout@v4
+      - uses: julia-actions/cache@v2
+      - name: Install JuliaFormatter and format
+        run: |
+          julia  -e 'using Pkg; Pkg.add(PackageSpec(name = "JuliaFormatter", version="1.0.60"))'
+          julia  -e 'using JuliaFormatter; format(["src/P4est.jl", "src/pointerwrappers.jl", "test"])'
+      - name: Format check
+        run: |
+          julia -e '
+          out = Cmd(`git diff --name-only`) |> read |> String
+          if out == ""
+              exit(0)
+          else
+              @error "Some files have not been formatted !!!"
+              write(stdout, out)
+              exit(1)
+          end'


### PR DESCRIPTION
The formatter is currently failing because it uses JuliaFormatter.jl v2, which leads to different formatting. This PR switches back to JuliaFormatter.jl v1 and uses the julia-format action as done in Trixi.jl.