### PR TITLE
Updates to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,13 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      # Group all Julia package updates into a single PR:
-      all-julia-dependencies:
+      # Group updates for P4est_jll.jl and all other julia packages into separate PRs
+      # because we usually want to update P4est_jll.jl separately.
+      p4est-jll:
+        patterns:
+          - "P4est_jll"
+      all-julia-packages-except-p4est-jll:
         patterns:
           - "*"
+        exclude-patterns:
+          - "P4est_jll"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@ updates:
   - package-ecosystem: "julia"
     directories: # Location of Julia projects
       - "/"
-      - "/dev"
       - "/docs"
       - "/test"
     schedule:

--- a/dev/Project.toml
+++ b/dev/Project.toml
@@ -6,6 +6,7 @@ MPI = "da04e1cc-30fd-572f-bb4f-1f8673147195"
 P4est_jll = "6b5a15aa-cf52-5330-8376-5e5d90283449"
 
 [compat]
+Artifacts = "1.3"
 CEnum = "0.4"
 Clang = "0.17.7"
 MPI = "0.20"


### PR DESCRIPTION
This PR adds a missing compat entry for Artifacts.jl in dev/Project.toml, excludes the dev/ project from updates by dependabot and groups the PRs by dependabot for julia package dependencies into two groups: One only for P4est_jll.jl and one for the remaning packages (I hope I did the configuration correctly).

Closes #171.